### PR TITLE
Fetch test JSON from dotnet/core release-index branch

### DIFF
--- a/test/Dotnet.Release.Graph.Tests/CveDeserializationTests.cs
+++ b/test/Dotnet.Release.Graph.Tests/CveDeserializationTests.cs
@@ -6,17 +6,13 @@ namespace Dotnet.Release.Graph.Tests;
 
 public class CveDeserializationTests
 {
-    private static readonly string CoreRoot = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        "git", "core", "release-notes");
+    private static readonly HttpClient Http = new();
 
     [Fact]
-    public void CveRecords_Deserializes()
+    public async Task CveRecords_Deserializes()
     {
-        var path = Path.Combine(CoreRoot, "timeline", "2025", "10", "cve.json");
-        Assert.True(File.Exists(path), $"File not found: {path}");
-
-        var json = File.ReadAllText(path);
+        var url = $"{TestConstants.BaseUrl}timeline/2025/10/cve.json";
+        var json = await Http.GetStringAsync(url);
         var records = JsonSerializer.Deserialize<CveRecords>(json, SerializerOptions.SnakeCase);
         Assert.NotNull(records);
         Assert.NotNull(records.Title);

--- a/test/Dotnet.Release.Graph.Tests/ReleasesDeserializationTests.cs
+++ b/test/Dotnet.Release.Graph.Tests/ReleasesDeserializationTests.cs
@@ -6,17 +6,13 @@ namespace Dotnet.Release.Graph.Tests;
 
 public class ReleasesDeserializationTests
 {
-    private static readonly string CoreRoot = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        "git", "core", "release-notes");
+    private static readonly HttpClient Http = new();
 
     [Fact]
-    public void ReleasesIndex_Deserializes()
+    public async Task ReleasesIndex_Deserializes()
     {
-        var path = Path.Combine(CoreRoot, "releases-index.json");
-        Assert.True(File.Exists(path), $"File not found: {path}");
-
-        var json = File.ReadAllText(path);
+        var url = $"{TestConstants.BaseUrl}releases-index.json";
+        var json = await Http.GetStringAsync(url);
         var index = JsonSerializer.Deserialize<MajorReleasesIndex>(json, SerializerOptions.KebabCase);
         Assert.NotNull(index);
         Assert.True(index.ReleasesIndex.Count > 0);

--- a/test/Dotnet.Release.Graph.Tests/SupportDeserializationTests.cs
+++ b/test/Dotnet.Release.Graph.Tests/SupportDeserializationTests.cs
@@ -6,17 +6,13 @@ namespace Dotnet.Release.Graph.Tests;
 
 public class SupportDeserializationTests
 {
-    private static readonly string CoreRoot = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        "git", "core", "release-notes");
+    private static readonly HttpClient Http = new();
 
     [Fact]
-    public void SupportedOSMatrix_Deserializes()
+    public async Task SupportedOSMatrix_Deserializes()
     {
-        var path = Path.Combine(CoreRoot, "9.0", "supported-os.json");
-        Assert.True(File.Exists(path), $"File not found: {path}");
-
-        var json = File.ReadAllText(path);
+        var url = $"{TestConstants.BaseUrl}9.0/supported-os.json";
+        var json = await Http.GetStringAsync(url);
         var matrix = JsonSerializer.Deserialize<SupportedOSMatrix>(json, SerializerOptions.KebabCase);
         Assert.NotNull(matrix);
         Assert.Equal("9.0", matrix.ChannelVersion);
@@ -25,12 +21,10 @@ public class SupportDeserializationTests
     }
 
     [Fact]
-    public void OSPackages_Deserializes()
+    public async Task OSPackages_Deserializes()
     {
-        var path = Path.Combine(CoreRoot, "9.0", "os-packages.json");
-        Assert.True(File.Exists(path), $"File not found: {path}");
-
-        var json = File.ReadAllText(path);
+        var url = $"{TestConstants.BaseUrl}9.0/os-packages.json";
+        var json = await Http.GetStringAsync(url);
         var packages = JsonSerializer.Deserialize<OSPackagesOverview>(json, SerializerOptions.KebabCase);
         Assert.NotNull(packages);
         Assert.Equal("9.0", packages.ChannelVersion);

--- a/test/Dotnet.Release.Graph.Tests/TestConstants.cs
+++ b/test/Dotnet.Release.Graph.Tests/TestConstants.cs
@@ -1,0 +1,6 @@
+namespace Dotnet.Release.Graph.Tests;
+
+internal static class TestConstants
+{
+    public const string BaseUrl = "https://raw.githubusercontent.com/dotnet/core/refs/heads/release-index/release-notes/";
+}


### PR DESCRIPTION
Tests now use HttpClient to fetch JSON from the `release-index` branch on GitHub instead of reading local files, so CI can run without a local clone of dotnet/core.