### PR TITLE
Add Phase 2: Client library and serializer contexts

### DIFF
--- a/DotnetRelease.slnx
+++ b/DotnetRelease.slnx
@@ -5,8 +5,10 @@
     <Project Path="src/Dotnet.Release.Releases/Dotnet.Release.Releases.csproj" />
     <Project Path="src/Dotnet.Release.Cve/Dotnet.Release.Cve.csproj" />
     <Project Path="src/Dotnet.Release.Support/Dotnet.Release.Support.csproj" />
+    <Project Path="src/Dotnet.Release.Client/Dotnet.Release.Client.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Dotnet.Release.Graph.Tests/Dotnet.Release.Graph.Tests.csproj" />
+    <Project Path="test/Dotnet.Release.Client.Tests/Dotnet.Release.Client.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@
 | `Dotnet.Release.Releases` | Legacy releases.json schema types |
 | `Dotnet.Release.Cve` | CVE disclosure schema types |
 | `Dotnet.Release.Support` | OS support matrix and package types |
+| `Dotnet.Release.Client` | Client library for navigating the release graph |

--- a/src/Dotnet.Release.Client/ArchiveNavigator.cs
+++ b/src/Dotnet.Release.Client/ArchiveNavigator.cs
@@ -1,0 +1,56 @@
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Deep navigation into a specific year of .NET release history.
+/// Data is fetched lazily and cached automatically.
+/// </summary>
+public class ArchiveNavigator
+{
+    private readonly ReleaseNotesGraph _graph;
+
+    public ArchiveNavigator(ReleaseNotesGraph graph, string year)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(year);
+        _graph = graph;
+        Year = year;
+    }
+
+    public string Year { get; }
+
+    public async Task<HistoryYearIndex> GetYearIndexAsync(CancellationToken cancellationToken = default)
+        => await _graph.GetYearIndexAsync(Year, cancellationToken)
+            ?? throw new InvalidOperationException($"Failed to load year index for {Year}");
+
+    public async Task<IEnumerable<MonthSummary>> GetAllMonthsAsync(CancellationToken cancellationToken = default)
+    {
+        var index = await GetYearIndexAsync(cancellationToken);
+        return index.Embedded?.Months?.Select(m => new MonthSummary(m, Year))
+            ?? Enumerable.Empty<MonthSummary>();
+    }
+
+    public async Task<MonthSummary?> GetMonthAsync(string month, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(month);
+        return (await GetAllMonthsAsync(cancellationToken)).FirstOrDefault(m => m.Month == month);
+    }
+
+    public async Task<IEnumerable<MonthSummary>> GetMonthsWithSecurityAsync(CancellationToken cancellationToken = default)
+        => (await GetAllMonthsAsync(cancellationToken)).Where(m => m.Security);
+
+    public async Task<CveRecords?> GetCveRecordsForMonthAsync(string month, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(month);
+
+        var monthIndex = await _graph.GetMonthIndexAsync(Year, month, cancellationToken);
+        if (monthIndex?.Links is null || !monthIndex.Links.TryGetValue(LinkRelations.CveJson, out var cveLink))
+        {
+            return null;
+        }
+
+        return await _graph.FollowLinkAsync<CveRecords>(cveLink, cancellationToken);
+    }
+}

--- a/src/Dotnet.Release.Client/ArchivesSummary.cs
+++ b/src/Dotnet.Release.Client/ArchivesSummary.cs
@@ -1,0 +1,74 @@
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// High-level summary of .NET release history archives with CVE information.
+/// </summary>
+public class ArchivesSummary
+{
+    private readonly ReleaseNotesGraph _graph;
+
+    public ArchivesSummary(ReleaseNotesGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        _graph = graph;
+    }
+
+    public async Task<IEnumerable<YearSummary>> GetAllYearsAsync(CancellationToken cancellationToken = default)
+    {
+        var historyIndex = await _graph.GetReleaseHistoryIndexAsync(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to load release history index");
+        return historyIndex.Embedded?.Years?.Select(y => new YearSummary(y))
+            ?? Enumerable.Empty<YearSummary>();
+    }
+
+    public async Task<YearSummary?> GetYearAsync(string year, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(year);
+        return (await GetAllYearsAsync(cancellationToken)).FirstOrDefault(y => y.Year == year);
+    }
+
+    public async Task<YearSummary?> GetLatestYearAsync(CancellationToken cancellationToken = default)
+        => (await GetAllYearsAsync(cancellationToken)).FirstOrDefault();
+
+    public async Task<IEnumerable<CveRecords>> GetCveRecordsInDateRangeAsync(
+        int startYear, int startMonth, int endYear, int endMonth,
+        CancellationToken cancellationToken = default)
+    {
+        var allRecords = new List<CveRecords>();
+
+        for (int year = startYear; year <= endYear; year++)
+        {
+            var navigator = new ArchiveNavigator(_graph, year.ToString());
+            var months = await navigator.GetAllMonthsAsync(cancellationToken);
+
+            foreach (var month in months.Where(m => m.Security))
+            {
+                var monthNum = int.Parse(month.Month);
+                if (year == startYear && monthNum < startMonth) continue;
+                if (year == endYear && monthNum > endMonth) continue;
+
+                var records = await navigator.GetCveRecordsForMonthAsync(month.Month, cancellationToken);
+                if (records is not null)
+                {
+                    allRecords.Add(records);
+                }
+            }
+        }
+
+        return allRecords;
+    }
+
+    public async Task<IEnumerable<CveRecords>> GetRecentCveRecordsAsync(
+        int monthsBack,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        var start = now.AddMonths(-monthsBack);
+        return await GetCveRecordsInDateRangeAsync(start.Year, start.Month, now.Year, now.Month, cancellationToken);
+    }
+
+    public ArchiveNavigator GetNavigator(string year) => new(_graph, year);
+}

--- a/src/Dotnet.Release.Client/CachingLinkFollower.cs
+++ b/src/Dotnet.Release.Client/CachingLinkFollower.cs
@@ -1,0 +1,86 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// ILinkFollower implementation that caches fetched documents by URL.
+/// Thread-safe for concurrent access.
+/// </summary>
+public class CachingLinkFollower : ILinkFollower
+{
+    private readonly HttpClient _client;
+    private readonly ConcurrentDictionary<string, object> _cache = new();
+
+    public CachingLinkFollower(HttpClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+    }
+
+    public async Task<T?> FetchAsync<T>(string href, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(href);
+
+        if (_cache.TryGetValue(href, out var cached))
+        {
+            return (T)cached;
+        }
+
+        var typeInfo = GetTypeInfo<T>();
+        var document = await FetchDocumentAsync(href, typeInfo, cancellationToken);
+
+        if (document is not null)
+        {
+            _cache[href] = document;
+        }
+
+        return document;
+    }
+
+    /// <summary>
+    /// Clears all cached documents.
+    /// </summary>
+    public void Clear() => _cache.Clear();
+
+    /// <summary>
+    /// Attempts to remove a specific URL from the cache.
+    /// </summary>
+    public bool TryEvict(string href) => _cache.TryRemove(href, out _);
+
+    private async Task<T?> FetchDocumentAsync<T>(string url, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken) where T : class
+    {
+        try
+        {
+            using var stream = await _client.GetStreamAsync(url, cancellationToken);
+            return await JsonSerializer.DeserializeAsync(stream, typeInfo, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private static JsonTypeInfo<T> GetTypeInfo<T>() where T : class
+    {
+        return typeof(T).Name switch
+        {
+            nameof(MajorReleaseVersionIndex) => (JsonTypeInfo<T>)(object)ReleaseVersionIndexSerializerContext.Default.MajorReleaseVersionIndex,
+            nameof(PatchReleaseVersionIndex) => (JsonTypeInfo<T>)(object)ReleaseVersionIndexSerializerContext.Default.PatchReleaseVersionIndex,
+            nameof(PatchDetailIndex) => (JsonTypeInfo<T>)(object)ReleaseVersionIndexSerializerContext.Default.PatchDetailIndex,
+            nameof(ReleaseManifest) => (JsonTypeInfo<T>)(object)ReleaseManifestSerializerContext.Default.ReleaseManifest,
+            nameof(ReleaseHistoryIndex) => (JsonTypeInfo<T>)(object)ReleaseHistoryIndexSerializerContext.Default.ReleaseHistoryIndex,
+            nameof(HistoryYearIndex) => (JsonTypeInfo<T>)(object)HistoryYearIndexSerializerContext.Default.HistoryYearIndex,
+            nameof(HistoryMonthIndex) => (JsonTypeInfo<T>)(object)HistoryYearIndexSerializerContext.Default.HistoryMonthIndex,
+            nameof(SdkVersionIndex) => (JsonTypeInfo<T>)(object)SdkVersionIndexSerializerContext.Default.SdkVersionIndex,
+            nameof(DownloadsIndex) => (JsonTypeInfo<T>)(object)DownloadsIndexSerializerContext.Default.DownloadsIndex,
+            nameof(TargetFrameworksIndex) => (JsonTypeInfo<T>)(object)TargetFrameworksSerializerContext.Default.TargetFrameworksIndex,
+            nameof(LlmsIndex) => (JsonTypeInfo<T>)(object)LlmsIndexSerializerContext.Default.LlmsIndex,
+            nameof(CveRecords) => (JsonTypeInfo<T>)(object)CveSerializerContext.Default.CveRecords,
+            _ => throw new NotSupportedException($"Type {typeof(T).Name} is not supported for deserialization")
+        };
+    }
+}

--- a/src/Dotnet.Release.Client/CveFilter.cs
+++ b/src/Dotnet.Release.Client/CveFilter.cs
@@ -1,0 +1,93 @@
+using Dotnet.Release.Cve;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Helper methods for filtering CVE records.
+/// </summary>
+public static class CveFilter
+{
+    /// <summary>
+    /// Filters CVEs to only those affecting a specific .NET version.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterByVersion(IEnumerable<CveRecords> cveRecords, string version)
+    {
+        ArgumentNullException.ThrowIfNull(cveRecords);
+        ArgumentNullException.ThrowIfNullOrEmpty(version);
+
+        var affectedCveIds = new HashSet<string>();
+
+        foreach (var records in cveRecords)
+        {
+            foreach (var product in records.Products.Where(p => p.Release == version))
+            {
+                affectedCveIds.Add(product.CveId);
+            }
+        }
+
+        return cveRecords
+            .SelectMany(r => r.Disclosures)
+            .Where(c => affectedCveIds.Contains(c.Id))
+            .DistinctBy(c => c.Id);
+    }
+
+    /// <summary>
+    /// Filters CVEs to only those affecting a specific platform.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterByPlatform(IEnumerable<Dotnet.Release.Cve.Cve> cves, string platform, bool includeAll = true)
+    {
+        ArgumentNullException.ThrowIfNull(cves);
+        ArgumentNullException.ThrowIfNullOrEmpty(platform);
+
+        return cves.Where(c =>
+            c.Platforms.Any(p => p.Equals(platform, StringComparison.OrdinalIgnoreCase)) ||
+            (includeAll && c.Platforms.Any(p => p.Equals("all", StringComparison.OrdinalIgnoreCase))));
+    }
+
+    /// <summary>
+    /// Filters CVEs to only those affecting specific platforms.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterByPlatforms(IEnumerable<Dotnet.Release.Cve.Cve> cves, IEnumerable<string> platforms, bool includeAll = true)
+    {
+        ArgumentNullException.ThrowIfNull(cves);
+        ArgumentNullException.ThrowIfNull(platforms);
+
+        var platformSet = new HashSet<string>(platforms, StringComparer.OrdinalIgnoreCase);
+
+        return cves.Where(c =>
+            c.Platforms.Any(p => platformSet.Contains(p)) ||
+            (includeAll && c.Platforms.Any(p => p.Equals("all", StringComparison.OrdinalIgnoreCase))));
+    }
+
+    /// <summary>
+    /// Filters CVEs by severity level.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterBySeverity(IEnumerable<Dotnet.Release.Cve.Cve> cves, string severity)
+    {
+        ArgumentNullException.ThrowIfNull(cves);
+        ArgumentNullException.ThrowIfNullOrEmpty(severity);
+
+        return cves.Where(c => c.Cvss.Severity.Equals(severity, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Filters CVEs to only Critical and High severity.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterHighSeverity(IEnumerable<Dotnet.Release.Cve.Cve> cves)
+    {
+        ArgumentNullException.ThrowIfNull(cves);
+        return cves.Where(c =>
+            c.Cvss.Severity.Equals("Critical", StringComparison.OrdinalIgnoreCase) ||
+            c.Cvss.Severity.Equals("High", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Combines filtering by version and platform.
+    /// </summary>
+    public static IEnumerable<Dotnet.Release.Cve.Cve> FilterByVersionAndPlatform(
+        IEnumerable<CveRecords> cveRecords, string version, string platform, bool includeAllPlatforms = true)
+    {
+        var versionFiltered = FilterByVersion(cveRecords, version);
+        return FilterByPlatform(versionFiltered, platform, includeAllPlatforms);
+    }
+}

--- a/src/Dotnet.Release.Client/Dotnet.Release.Client.csproj
+++ b/src/Dotnet.Release.Client/Dotnet.Release.Client.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dotnet.Release.Client</PackageId>
+    <Description>Client library for navigating the .NET release notes graph</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Release.Graph\Dotnet.Release.Graph.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Cve\Dotnet.Release.Cve.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Releases\Dotnet.Release.Releases.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Support\Dotnet.Release.Support.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dotnet.Release.Client/ILinkFollower.cs
+++ b/src/Dotnet.Release.Client/ILinkFollower.cs
@@ -1,0 +1,13 @@
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Abstraction for fetching HAL+JSON documents by URL.
+/// Implementations can provide caching, mocking, or other strategies.
+/// </summary>
+public interface ILinkFollower
+{
+    /// <summary>
+    /// Fetches a document of type T from the specified href URL.
+    /// </summary>
+    Task<T?> FetchAsync<T>(string href, CancellationToken cancellationToken = default) where T : class;
+}

--- a/src/Dotnet.Release.Client/MonthSummary.cs
+++ b/src/Dotnet.Release.Client/MonthSummary.cs
@@ -1,0 +1,25 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Summary of .NET release history for a specific month.
+/// </summary>
+public class MonthSummary
+{
+    private readonly HistoryMonthSummary _monthSummary;
+
+    public MonthSummary(HistoryMonthSummary monthSummary, string year)
+    {
+        ArgumentNullException.ThrowIfNull(monthSummary);
+        ArgumentNullException.ThrowIfNull(year);
+        _monthSummary = monthSummary;
+        Year = year;
+    }
+
+    public string Year { get; }
+    public string Month => _monthSummary.Month;
+    public string YearMonth => $"{Year}-{Month}";
+    public bool Security => _monthSummary.Security;
+    public IReadOnlyDictionary<string, HalLink>? Links => _monthSummary.Links;
+}

--- a/src/Dotnet.Release.Client/PatchSummary.cs
+++ b/src/Dotnet.Release.Client/PatchSummary.cs
@@ -1,0 +1,23 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Summary of a .NET patch release.
+/// </summary>
+public class PatchSummary
+{
+    private readonly PatchReleaseVersionIndexEntry _entry;
+
+    public PatchSummary(PatchReleaseVersionIndexEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _entry = entry;
+    }
+
+    public string Version => _entry.Version;
+    public SupportPhase? Phase => _entry.SupportPhase;
+    public DateTimeOffset? ReleaseDate => _entry.Date;
+    public bool IsSecurityUpdate => _entry.Security;
+    public IReadOnlyDictionary<string, HalLink>? Links => _entry.Links;
+}

--- a/src/Dotnet.Release.Client/ReleaseNavigator.cs
+++ b/src/Dotnet.Release.Client/ReleaseNavigator.cs
@@ -1,0 +1,52 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Deep navigation into a specific .NET major version.
+/// Data is fetched lazily and cached automatically.
+/// </summary>
+public class ReleaseNavigator
+{
+    private readonly ReleaseNotesGraph _graph;
+
+    public ReleaseNavigator(ReleaseNotesGraph graph, string version)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(version);
+        _graph = graph;
+        Version = version;
+    }
+
+    public string Version { get; }
+
+    public async Task<PatchReleaseVersionIndex> GetPatchIndexAsync(CancellationToken cancellationToken = default)
+        => await _graph.GetPatchReleaseIndexAsync(Version, cancellationToken)
+            ?? throw new InvalidOperationException($"Failed to load patch index for version {Version}");
+
+    public async Task<ReleaseManifest> GetManifestAsync(CancellationToken cancellationToken = default)
+        => await _graph.GetManifestAsync(Version, cancellationToken)
+            ?? throw new InvalidOperationException($"Failed to load manifest for version {Version}");
+
+    public async Task<IEnumerable<PatchSummary>> GetAllPatchesAsync(CancellationToken cancellationToken = default)
+    {
+        var index = await GetPatchIndexAsync(cancellationToken);
+        return index.Embedded?.Patches?.Select(r => new PatchSummary(r))
+            ?? Enumerable.Empty<PatchSummary>();
+    }
+
+    public async Task<PatchSummary?> GetLatestPatchAsync(CancellationToken cancellationToken = default)
+        => (await GetAllPatchesAsync(cancellationToken)).FirstOrDefault();
+
+    public async Task<PatchSummary?> GetPatchAsync(string patchVersion, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(patchVersion);
+        return (await GetAllPatchesAsync(cancellationToken)).FirstOrDefault(p => p.Version == patchVersion);
+    }
+
+    public async Task<IEnumerable<PatchSummary>> GetSecurityPatchesAsync(CancellationToken cancellationToken = default)
+        => (await GetAllPatchesAsync(cancellationToken)).Where(p => p.IsSecurityUpdate);
+
+    public async Task<bool> HasSecurityUpdatesAsync(CancellationToken cancellationToken = default)
+        => (await GetSecurityPatchesAsync(cancellationToken)).Any();
+}

--- a/src/Dotnet.Release.Client/ReleaseNotes.cs
+++ b/src/Dotnet.Release.Client/ReleaseNotes.cs
@@ -1,0 +1,17 @@
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Well-known base URIs for .NET release data.
+/// </summary>
+public static class ReleaseNotes
+{
+    /// <summary>
+    /// Official CDN base URI for release metadata.
+    /// </summary>
+    public const string OfficialBaseUri = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/";
+
+    /// <summary>
+    /// GitHub raw content base URI for release notes (release-index branch).
+    /// </summary>
+    public const string GitHubBaseUri = "https://raw.githubusercontent.com/dotnet/core/release-index/release-notes/";
+}

--- a/src/Dotnet.Release.Client/ReleaseNotesGraph.cs
+++ b/src/Dotnet.Release.Client/ReleaseNotesGraph.cs
@@ -1,0 +1,111 @@
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Provides programmatic access to the .NET release notes graph via HAL+JSON navigation.
+/// </summary>
+public class ReleaseNotesGraph
+{
+    private readonly ILinkFollower _linkFollower;
+    private readonly string _baseUrl;
+
+    public ReleaseNotesGraph(HttpClient client) : this(client, ReleaseNotes.GitHubBaseUri)
+    {
+    }
+
+    public ReleaseNotesGraph(HttpClient client, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNullOrEmpty(baseUrl);
+        _linkFollower = new CachingLinkFollower(client);
+        _baseUrl = baseUrl;
+    }
+
+    public ReleaseNotesGraph(ILinkFollower linkFollower, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(linkFollower);
+        ArgumentNullException.ThrowIfNullOrEmpty(baseUrl);
+        _linkFollower = linkFollower;
+        _baseUrl = baseUrl;
+    }
+
+    /// <summary>
+    /// Gets the root major release version index containing all .NET versions.
+    /// </summary>
+    public Task<MajorReleaseVersionIndex?> GetMajorReleaseIndexAsync(CancellationToken cancellationToken = default)
+        => _linkFollower.FetchAsync<MajorReleaseVersionIndex>($"{_baseUrl}index.json", cancellationToken);
+
+    /// <summary>
+    /// Gets the patch release index for a specific major version.
+    /// </summary>
+    public Task<PatchReleaseVersionIndex?> GetPatchReleaseIndexAsync(string version, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(version);
+        return _linkFollower.FetchAsync<PatchReleaseVersionIndex>($"{_baseUrl}{version}/index.json", cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the manifest for a specific major version.
+    /// </summary>
+    public Task<ReleaseManifest?> GetManifestAsync(string version, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(version);
+        return _linkFollower.FetchAsync<ReleaseManifest>($"{_baseUrl}{version}/manifest.json", cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the release history index (chronological view).
+    /// </summary>
+    public Task<ReleaseHistoryIndex?> GetReleaseHistoryIndexAsync(CancellationToken cancellationToken = default)
+        => _linkFollower.FetchAsync<ReleaseHistoryIndex>($"{_baseUrl}timeline/index.json", cancellationToken);
+
+    /// <summary>
+    /// Gets the history index for a specific year.
+    /// </summary>
+    public Task<HistoryYearIndex?> GetYearIndexAsync(string year, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(year);
+        return _linkFollower.FetchAsync<HistoryYearIndex>($"{_baseUrl}timeline/{year}/index.json", cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the history index for a specific year and month.
+    /// </summary>
+    public Task<HistoryMonthIndex?> GetMonthIndexAsync(string year, string month, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(year);
+        ArgumentNullException.ThrowIfNullOrEmpty(month);
+        return _linkFollower.FetchAsync<HistoryMonthIndex>($"{_baseUrl}timeline/{year}/{month}/index.json", cancellationToken);
+    }
+
+    /// <summary>
+    /// Follows a HAL link to fetch a document of the specified type.
+    /// </summary>
+    public Task<T?> FollowLinkAsync<T>(HalLink link, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(link);
+        return _linkFollower.FetchAsync<T>(link.Href, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a high-level summary of all .NET releases.
+    /// </summary>
+    public ReleasesSummary GetReleasesSummary() => new(this);
+
+    /// <summary>
+    /// Creates a navigator for a specific .NET major version.
+    /// </summary>
+    public ReleaseNavigator GetReleaseNavigator(string version) => new(this, version);
+
+    /// <summary>
+    /// Creates a high-level summary of release history archives.
+    /// </summary>
+    public ArchivesSummary GetArchivesSummary() => new(this);
+
+    /// <summary>
+    /// Creates a navigator for a specific year's release history.
+    /// </summary>
+    public ArchiveNavigator GetArchiveNavigator(string year) => new(this, year);
+}

--- a/src/Dotnet.Release.Client/ReleaseSummary.cs
+++ b/src/Dotnet.Release.Client/ReleaseSummary.cs
@@ -1,0 +1,30 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Summary of a .NET major version with support status.
+/// </summary>
+public class ReleaseSummary
+{
+    private readonly MajorReleaseVersionIndexEntry _entry;
+
+    public ReleaseSummary(MajorReleaseVersionIndexEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _entry = entry;
+    }
+
+    public string Version => _entry.Version;
+    public ReleaseType? ReleaseType => _entry.ReleaseType;
+    public SupportPhase? Phase => _entry.SupportPhase;
+    public DateTimeOffset? ReleaseDate => _entry.GaDate;
+    public DateTimeOffset? EolDate => _entry.EolDate;
+    public bool IsSupported => _entry.Supported ?? false;
+    public bool IsLts => ReleaseType == Release.ReleaseType.LTS;
+    public bool IsSts => ReleaseType == Release.ReleaseType.STS;
+    public bool IsActive => Phase == SupportPhase.Active;
+    public bool IsPreview => Phase == SupportPhase.Preview;
+    public bool IsEol => Phase == SupportPhase.Eol;
+    public IReadOnlyDictionary<string, HalLink>? Links => _entry.Links;
+}

--- a/src/Dotnet.Release.Client/ReleasesSummary.cs
+++ b/src/Dotnet.Release.Client/ReleasesSummary.cs
@@ -1,0 +1,57 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// High-level summary of all .NET releases with support status.
+/// </summary>
+public class ReleasesSummary
+{
+    private readonly ReleaseNotesGraph _graph;
+
+    public ReleasesSummary(ReleaseNotesGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        _graph = graph;
+    }
+
+    public async Task<IEnumerable<ReleaseSummary>> GetAllVersionsAsync(CancellationToken cancellationToken = default)
+    {
+        var index = await _graph.GetMajorReleaseIndexAsync(cancellationToken)
+            ?? throw new InvalidOperationException("Failed to load major release index");
+        return index.Embedded?.Releases?.Select(r => new ReleaseSummary(r))
+            ?? Enumerable.Empty<ReleaseSummary>();
+    }
+
+    public async Task<IEnumerable<ReleaseSummary>> GetSupportedVersionsAsync(CancellationToken cancellationToken = default)
+        => (await GetAllVersionsAsync(cancellationToken)).Where(r => r.IsSupported);
+
+    public async Task<IEnumerable<ReleaseSummary>> GetVersionsByPhaseAsync(SupportPhase phase, CancellationToken cancellationToken = default)
+        => (await GetAllVersionsAsync(cancellationToken)).Where(r => r.Phase == phase);
+
+    public async Task<IEnumerable<ReleaseSummary>> GetVersionsByTypeAsync(ReleaseType type, CancellationToken cancellationToken = default)
+        => (await GetAllVersionsAsync(cancellationToken)).Where(r => r.ReleaseType == type);
+
+    public async Task<ReleaseSummary?> GetLatestAsync(CancellationToken cancellationToken = default)
+        => (await GetAllVersionsAsync(cancellationToken)).FirstOrDefault();
+
+    public async Task<ReleaseSummary?> GetLatestLtsAsync(CancellationToken cancellationToken = default)
+        => (await GetVersionsByTypeAsync(ReleaseType.LTS, cancellationToken)).FirstOrDefault();
+
+    public async Task<ReleaseSummary?> GetLatestStsAsync(CancellationToken cancellationToken = default)
+        => (await GetVersionsByTypeAsync(ReleaseType.STS, cancellationToken)).FirstOrDefault();
+
+    public async Task<ReleaseSummary?> GetLatestSupportedAsync(CancellationToken cancellationToken = default)
+        => (await GetSupportedVersionsAsync(cancellationToken)).FirstOrDefault();
+
+    public async Task<ReleaseSummary?> GetVersionAsync(string version, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(version);
+        return (await GetAllVersionsAsync(cancellationToken)).FirstOrDefault(r => r.Version == version);
+    }
+
+    public async Task<bool> IsSupportedAsync(string version, CancellationToken cancellationToken = default)
+        => (await GetVersionAsync(version, cancellationToken))?.IsSupported ?? false;
+
+    public ReleaseNavigator GetNavigator(string version) => new(_graph, version);
+}

--- a/src/Dotnet.Release.Client/YearSummary.cs
+++ b/src/Dotnet.Release.Client/YearSummary.cs
@@ -1,0 +1,23 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.Client;
+
+/// <summary>
+/// Summary of .NET release history for a specific year.
+/// </summary>
+public class YearSummary
+{
+    private readonly HistoryYearEntry _yearEntry;
+
+    public YearSummary(HistoryYearEntry yearEntry)
+    {
+        ArgumentNullException.ThrowIfNull(yearEntry);
+        _yearEntry = yearEntry;
+    }
+
+    public string Year => _yearEntry.Year;
+    public string? Description => _yearEntry.Description;
+    public IList<string>? MajorReleases => _yearEntry.MajorReleases;
+    public int MajorReleaseCount => MajorReleases?.Count ?? 0;
+    public IReadOnlyDictionary<string, HalLink> Links => _yearEntry.Links;
+}

--- a/src/Dotnet.Release.Cve/CveSerializerContext.cs
+++ b/src/Dotnet.Release.Cve/CveSerializerContext.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Cve;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(CveRecords))]
+[JsonSerializable(typeof(Event))]
+[JsonSerializable(typeof(IList<Event>))]
+[JsonSerializable(typeof(List<Event>))]
+[JsonSerializable(typeof(CnaFaq))]
+[JsonSerializable(typeof(IList<CnaFaq>))]
+[JsonSerializable(typeof(List<CnaFaq>))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(IList<string>))]
+public partial class CveSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Graph/SerializerContexts.cs
+++ b/src/Dotnet.Release.Graph/SerializerContexts.cs
@@ -1,0 +1,85 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Graph;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(MajorReleaseVersionIndex))]
+[JsonSerializable(typeof(PatchReleaseVersionIndex))]
+[JsonSerializable(typeof(PatchDetailIndex))]
+[JsonSerializable(typeof(MajorReleaseVersionIndexEntry))]
+[JsonSerializable(typeof(PatchReleaseVersionIndexEntry))]
+[JsonSerializable(typeof(Lifecycle))]
+[JsonSerializable(typeof(PatchLifecycle))]
+[JsonSerializable(typeof(CveRecordSummary))]
+public partial class ReleaseVersionIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(ReleaseManifest))]
+public partial class ReleaseManifestSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(ReleaseHistoryIndex))]
+public partial class ReleaseHistoryIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(HistoryYearIndex))]
+[JsonSerializable(typeof(HistoryMonthIndex))]
+[JsonSerializable(typeof(HistoryMonthSummary))]
+[JsonSerializable(typeof(CveRecordSummary))]
+[JsonSerializable(typeof(HalLink))]
+public partial class HistoryYearIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(SdkVersionIndex))]
+[JsonSerializable(typeof(SdkDownloadInfo))]
+[JsonSerializable(typeof(SdkDownloadEmbedded))]
+[JsonSerializable(typeof(SdkDownloadFile))]
+public partial class SdkVersionIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(DownloadsIndex))]
+[JsonSerializable(typeof(ComponentDownload))]
+[JsonSerializable(typeof(DownloadFile))]
+public partial class DownloadsIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(TargetFrameworksIndex))]
+public partial class TargetFrameworksSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(LlmsIndex))]
+[JsonSerializable(typeof(LlmsWorkflow))]
+[JsonSerializable(typeof(HistoryMonthSummary))]
+public partial class LlmsIndexSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Releases/ReleasesSerializerContexts.cs
+++ b/src/Dotnet.Release.Releases/ReleasesSerializerContexts.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Releases;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(MajorReleasesIndex))]
+public partial class MajorReleasesIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(MajorReleaseOverview))]
+public partial class MajorReleaseOverviewSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(PatchReleaseOverview))]
+public partial class PatchReleaseOverviewSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Support/SupportSerializerContexts.cs
+++ b/src/Dotnet.Release.Support/SupportSerializerContexts.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Support;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(OSPackagesOverview))]
+public partial class OSPackagesSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(SupportedOSMatrix))]
+public partial class SupportedOSMatrixSerializerContext : JsonSerializerContext
+{
+}

--- a/test/Dotnet.Release.Client.Tests/Dotnet.Release.Client.Tests.csproj
+++ b/test/Dotnet.Release.Client.Tests/Dotnet.Release.Client.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dotnet.Release.Client.Tests</PackageId>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dotnet.Release.Client\Dotnet.Release.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Dotnet.Release.Client.Tests/GraphNavigationTests.cs
+++ b/test/Dotnet.Release.Client.Tests/GraphNavigationTests.cs
@@ -1,0 +1,65 @@
+using Dotnet.Release.Client;
+using Dotnet.Release.Graph;
+using Xunit;
+
+namespace Dotnet.Release.Client.Tests;
+
+public class GraphNavigationTests
+{
+    private static readonly HttpClient _client = new();
+
+    private ReleaseNotesGraph CreateGraph() => new(_client);
+
+    [Fact]
+    public async Task GetMajorReleaseIndex_ReturnsVersions()
+    {
+        var graph = CreateGraph();
+        var index = await graph.GetMajorReleaseIndexAsync();
+
+        Assert.NotNull(index);
+        Assert.NotNull(index.Embedded?.Releases);
+        Assert.True(index.Embedded.Releases.Count > 0);
+    }
+
+    [Fact]
+    public async Task GetPatchReleaseIndex_ReturnsPatchesFor9()
+    {
+        var graph = CreateGraph();
+        var index = await graph.GetPatchReleaseIndexAsync("9.0");
+
+        Assert.NotNull(index);
+        Assert.NotNull(index.Embedded?.Patches);
+        Assert.True(index.Embedded.Patches.Count > 0);
+    }
+
+    [Fact]
+    public async Task GetManifest_ReturnsManifestFor9()
+    {
+        var graph = CreateGraph();
+        var manifest = await graph.GetManifestAsync("9.0");
+
+        Assert.NotNull(manifest);
+        Assert.Equal("9.0", manifest.Version);
+    }
+
+    [Fact]
+    public async Task GetReleaseHistoryIndex_ReturnsYears()
+    {
+        var graph = CreateGraph();
+        var history = await graph.GetReleaseHistoryIndexAsync();
+
+        Assert.NotNull(history);
+        Assert.NotNull(history.Embedded?.Years);
+        Assert.True(history.Embedded.Years.Count > 0);
+    }
+
+    [Fact]
+    public async Task GetYearIndex_Returns2025()
+    {
+        var graph = CreateGraph();
+        var year = await graph.GetYearIndexAsync("2025");
+
+        Assert.NotNull(year);
+        Assert.Equal("2025", year.Year);
+    }
+}

--- a/test/Dotnet.Release.Client.Tests/SummaryTests.cs
+++ b/test/Dotnet.Release.Client.Tests/SummaryTests.cs
@@ -1,0 +1,76 @@
+using Dotnet.Release.Client;
+using Xunit;
+
+namespace Dotnet.Release.Client.Tests;
+
+public class SummaryTests
+{
+    private static readonly HttpClient _client = new();
+
+    private ReleaseNotesGraph CreateGraph() => new(_client);
+
+    [Fact]
+    public async Task ReleasesSummary_GetAllVersions()
+    {
+        var summary = CreateGraph().GetReleasesSummary();
+        var versions = await summary.GetAllVersionsAsync();
+
+        Assert.NotEmpty(versions);
+    }
+
+    [Fact]
+    public async Task ReleasesSummary_GetSupportedVersions()
+    {
+        var summary = CreateGraph().GetReleasesSummary();
+        var supported = await summary.GetSupportedVersionsAsync();
+
+        Assert.NotEmpty(supported);
+        Assert.All(supported, r => Assert.True(r.IsSupported));
+    }
+
+    [Fact]
+    public async Task ReleasesSummary_GetLatestLts()
+    {
+        var summary = CreateGraph().GetReleasesSummary();
+        var latest = await summary.GetLatestLtsAsync();
+
+        Assert.NotNull(latest);
+        Assert.True(latest.IsLts);
+    }
+
+    [Fact]
+    public async Task ReleaseNavigator_GetAllPatches()
+    {
+        var nav = CreateGraph().GetReleaseNavigator("9.0");
+        var patches = await nav.GetAllPatchesAsync();
+
+        Assert.NotEmpty(patches);
+    }
+
+    [Fact]
+    public async Task ReleaseNavigator_GetSecurityPatches()
+    {
+        var nav = CreateGraph().GetReleaseNavigator("9.0");
+        var secPatches = await nav.GetSecurityPatchesAsync();
+
+        Assert.All(secPatches, p => Assert.True(p.IsSecurityUpdate));
+    }
+
+    [Fact]
+    public async Task ArchivesSummary_GetAllYears()
+    {
+        var summary = CreateGraph().GetArchivesSummary();
+        var years = await summary.GetAllYearsAsync();
+
+        Assert.NotEmpty(years);
+    }
+
+    [Fact]
+    public async Task ArchiveNavigator_GetMonths()
+    {
+        var nav = CreateGraph().GetArchiveNavigator("2025");
+        var months = await nav.GetAllMonthsAsync();
+
+        Assert.NotEmpty(months);
+    }
+}


### PR DESCRIPTION
## Changes

### Source-generated serializer contexts (in domain packages)
- `Dotnet.Release.Graph`: 8 contexts (SnakeCaseLower) for all HAL+JSON types
- `Dotnet.Release.Cve`: CveSerializerContext (SnakeCaseLower)
- `Dotnet.Release.Releases`: 3 contexts (KebabCaseLower)
- `Dotnet.Release.Support`: 2 contexts (KebabCaseLower)

### Dotnet.Release.Client package
- **ILinkFollower** — abstraction for fetching HAL+JSON documents
- **CachingLinkFollower** — thread-safe, AOT-compatible HTTP fetcher with in-memory cache
- **ReleaseNotesGraph** — core graph navigator (root, major, patch, timeline indexes)
- **ReleaseNavigator** — drill into a specific .NET version's patches
- **ArchiveNavigator** — drill into a year's release history and CVE data
- **ReleasesSummary / ArchivesSummary** — high-level query facades
- **ReleaseSummary, PatchSummary, MonthSummary, YearSummary** — convenience wrappers
- **CveFilter** — static helpers for version/platform/severity filtering
- **ReleaseNotes** — well-known base URI constants

### Tests
- 12 new client integration tests (GraphNavigationTests + SummaryTests)
- All 24 tests pass (12 POCO + 12 client)