### PR TITLE
Add endoflife.date support and local/remote path handling

### DIFF
--- a/src/Dotnet.Release.Tools.SupportedOs/EndOfLifeDate.cs
+++ b/src/Dotnet.Release.Tools.SupportedOs/EndOfLifeDate.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Tools.SupportedOs;
+
+/// <summary>
+/// Client for the endoflife.date API.
+/// </summary>
+public static class EndOfLifeDate
+{
+    private const string BaseUrl = "https://endoflife.date/api/";
+
+    public static Task<SupportCycle?> GetProductCycleAsync(HttpClient client, string product, string cycle)
+        => client.GetFromJsonAsync($"{BaseUrl}{product}/{cycle}.json", EolSerializerContext.Default.SupportCycle);
+}
+
+public record SupportCycle(string Cycle, string Codename, DateOnly ReleaseDate, string? Link)
+{
+    [JsonConverter(typeof(EolStringConverter))]
+    public string? Eol { get; set; }
+
+    [JsonConverter(typeof(EolStringConverter))]
+    public string? Lts { get; set; }
+
+    public string? LatestReleaseDate { get; set; }
+
+    public SupportInfo GetSupportInfo()
+    {
+        if (Eol is "False")
+            return new(true, DateOnly.MaxValue);
+
+        if (Eol is not null && DateOnly.TryParse(Eol, out DateOnly eolDate))
+            return new(eolDate > DateOnly.FromDateTime(DateTime.UtcNow), eolDate);
+
+        return new(false, DateOnly.MinValue);
+    }
+}
+
+public record struct SupportInfo(bool IsActive, DateOnly EolDate);
+
+/// <summary>
+/// Handles endoflife.date's eol/lts fields which can be bool or string.
+/// </summary>
+public class EolStringConverter : JsonConverter<string>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.TokenType switch
+    {
+        JsonTokenType.True => "True",
+        JsonTokenType.False => "False",
+        _ => reader.GetString()
+    };
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value);
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.KebabCaseLower)]
+[JsonSerializable(typeof(SupportCycle))]
+internal partial class EolSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Tools.SupportedOs/Program.cs
+++ b/src/Dotnet.Release.Tools.SupportedOs/Program.cs
@@ -1,34 +1,62 @@
 using System.Text.Json;
+using Dotnet.Release;
 using Dotnet.Release.Support;
 using Dotnet.Release.Tools.SupportedOs;
 
-// Usage: dotnet run -- <version> [url-or-path]
-// Example: dotnet run -- 9.0
-//          dotnet run -- 9.0 https://raw.githubusercontent.com/dotnet/core/release-index/release-notes/
+// Usage: dotnet-supported-os <version> [path-or-url]
+// Examples:
+//   dotnet-supported-os 9.0
+//   dotnet-supported-os 9.0 ~/git/core/release-notes
+//   dotnet-supported-os 9.0 https://raw.githubusercontent.com/dotnet/core/release-index/release-notes/
 
 if (args.Length == 0 || !decimal.TryParse(args[0], out _))
 {
-    Console.Error.WriteLine("Usage: Dotnet.Release.Tools.SupportedOs <version> [base-url]");
-    Console.Error.WriteLine("Example: dotnet run -- 9.0");
+    Console.Error.WriteLine("Usage: dotnet-supported-os <version> [path-or-url]");
+    Console.Error.WriteLine("Examples:");
+    Console.Error.WriteLine("  dotnet-supported-os 10.0");
+    Console.Error.WriteLine("  dotnet-supported-os 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-supported-os 10.0 https://builds.dotnet.microsoft.com/dotnet/release-metadata/");
     return 1;
 }
 
 string version = args[0];
-string baseUrl = args.Length > 1
+string basePath = args.Length > 1
     ? args[1]
     : "https://raw.githubusercontent.com/dotnet/core/release-index/release-notes/";
 
-if (!baseUrl.EndsWith('/')) baseUrl += '/';
-
-string jsonUrl = $"{baseUrl}{version}/supported-os.json";
-
-Console.Error.WriteLine($"Fetching {jsonUrl}...");
-
 using var client = new HttpClient();
-using var stream = await client.GetStreamAsync(jsonUrl);
+var path = AdaptivePath.Create(basePath, client);
+
+// Load supported-os.json
+string jsonPath = path.Combine(version, "supported-os.json");
+Console.Error.WriteLine($"Reading {jsonPath}...");
+
+using var stream = await path.GetStreamAsync(jsonPath);
 var matrix = await JsonSerializer.DeserializeAsync(stream, SupportedOSMatrixSerializerContext.Default.SupportedOSMatrix)
     ?? throw new InvalidOperationException("Failed to deserialize supported-os.json");
 
-SupportedOsGenerator.Generate(matrix, Console.Out, version, supportPhase: "Active", releaseType: "STS");
+// Determine output: write to file alongside JSON when local, stdout otherwise
+TextWriter output;
+string? outputPath = null;
+
+if (path.SupportsLocalPaths)
+{
+    outputPath = path.Combine(version, "supported-os.md");
+    output = new StreamWriter(File.Open(outputPath, FileMode.Create));
+}
+else
+{
+    output = Console.Out;
+}
+
+await SupportedOsGenerator.GenerateAsync(matrix, output, version, client);
+
+if (outputPath is not null)
+{
+    await output.DisposeAsync();
+    var info = new FileInfo(outputPath);
+    Console.Error.WriteLine($"Generated {info.Length} bytes");
+    Console.Error.WriteLine(info.FullName);
+}
 
 return 0;

--- a/src/Dotnet.Release/AdaptivePath.cs
+++ b/src/Dotnet.Release/AdaptivePath.cs
@@ -1,0 +1,70 @@
+using System.Text;
+
+namespace Dotnet.Release;
+
+/// <summary>
+/// Abstraction for accessing files via local paths or HTTP URLs.
+/// </summary>
+public interface IAdaptivePath
+{
+    bool CanHandlePath(string path);
+    bool SupportsLocalPaths { get; }
+    string Combine(params Span<string> segments);
+    Task<Stream> GetStreamAsync(string uri);
+}
+
+/// <summary>
+/// Factory for creating the appropriate path handler.
+/// </summary>
+public static class AdaptivePath
+{
+    public static IAdaptivePath Create(string basePath, HttpClient client) =>
+        GetAdaptor(basePath, new WebPath(basePath, client), new FilePath(basePath));
+
+    public static IAdaptivePath GetAdaptor(string basePath, params Span<IAdaptivePath> adaptors)
+    {
+        foreach (var adaptor in adaptors)
+        {
+            if (adaptor.CanHandlePath(basePath))
+                return adaptor;
+        }
+
+        throw new NotSupportedException($"No adaptor found for path: {basePath}");
+    }
+
+    internal static string CombineSegments(string root, char slash, Span<string> segments)
+    {
+        var buffer = new StringBuilder();
+        buffer.Append(root.TrimEnd(slash, '/', '\\'));
+
+        foreach (var segment in segments)
+        {
+            buffer.Append(slash);
+            buffer.Append(segment);
+        }
+
+        return buffer.ToString();
+    }
+}
+
+/// <summary>
+/// Accesses files on the local file system.
+/// </summary>
+public class FilePath(string basePath) : IAdaptivePath
+{
+    public Task<Stream> GetStreamAsync(string uri) => Task.FromResult<Stream>(File.OpenRead(uri));
+    public string Combine(params Span<string> segments) => AdaptivePath.CombineSegments(basePath, Path.DirectorySeparatorChar, segments);
+    public bool CanHandlePath(string path) => true;
+    public bool SupportsLocalPaths => true;
+}
+
+/// <summary>
+/// Accesses files via HTTP.
+/// </summary>
+public class WebPath(string basePath, HttpClient client) : IAdaptivePath
+{
+    public Task<Stream> GetStreamAsync(string uri) => client.GetStreamAsync(uri);
+    public string Combine(params Span<string> segments) => AdaptivePath.CombineSegments(basePath, '/', segments);
+    public bool CanHandlePath(string path) => path.StartsWith("http://") || path.StartsWith("https://");
+    public bool SupportsLocalPaths => false;
+}


### PR DESCRIPTION
## Changes

### AdaptivePath (Dotnet.Release)
- `IAdaptivePath` interface unifying local file and HTTP access
- `FilePath` / `WebPath` implementations
- `AdaptivePath.Create(basePath, client)` factory

### EndOfLifeDate integration
- Fetches EOL dates from `endoflife.date` API for unsupported OS versions
- Generates "Out of support OS versions" section with EOL date table

### Local/remote path support
- `dotnet-supported-os 10.0 ~/git/core/release-notes` — reads local JSON, writes `supported-os.md` alongside it
- `dotnet-supported-os 10.0` — fetches from GitHub, writes to stdout
- Enables the workflow: edit JSON locally → run tool → PR both files together