### PR TITLE
Configure RID-specific AOT tool packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - rid: win-x64
+            os: windows-latest
+          - rid: win-arm64
+            os: windows-latest
           - rid: linux-x64
             os: ubuntu-latest
           - rid: linux-arm64
@@ -100,7 +104,7 @@ jobs:
 
       - name: Push RID-specific packages first
         run: |
-          for pkg in ./nupkg/*.linux-x64.*.nupkg ./nupkg/*.linux-arm64.*.nupkg ./nupkg/*.osx-arm64.*.nupkg ./nupkg/*.any.*.nupkg; do
+          for pkg in ./nupkg/*.win-x64.*.nupkg ./nupkg/*.win-arm64.*.nupkg ./nupkg/*.linux-x64.*.nupkg ./nupkg/*.linux-arm64.*.nupkg ./nupkg/*.osx-arm64.*.nupkg ./nupkg/*.any.*.nupkg; do
             [ -f "$pkg" ] && dotnet nuget push "$pkg" --source "${{ env.NUGET_SOURCE }}" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate || true
           done
 

--- a/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
+++ b/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
@@ -7,7 +7,7 @@
     <PackageId>Dotnet.Release.Tools.SupportedOs</PackageId>
     <Description>Generates supported-os.md from .NET release data</Description>
     <PublishAot>true</PublishAot>
-    <ToolPackageRuntimeIdentifiers>linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Configures the supported-os tool for RID-specific packaging with AOT compilation.

### Changes

- **`Dotnet.Release.Tools.SupportedOs.csproj`**: Added `ToolPackageRuntimeIdentifiers` for linux-x64, linux-arm64, osx-arm64, and any (CoreCLR fallback)
- **`publish.yml`**: Reworked into multi-job workflow:
  - `pack-libraries`: Packs library packages
  - `pack-tool-rid`: Matrix build for AOT packages (linux on ubuntu, macOS on macos)
  - `pack-tool-any`: CoreCLR fallback package (`-r any -p:PublishAot=false`)
  - `publish`: Downloads all artifacts, pushes RID packages before pointer package

### Package output

| Package | Size |
|---------|------|
| `Dotnet.Release.Tools.SupportedOs.1.0.0.nupkg` (pointer) | ~2 KB |
| `Dotnet.Release.Tools.SupportedOs.linux-x64.1.0.0.nupkg` (AOT) | ~7.6 MB |

Install with:
```
dotnet tool install dotnet-supported-os --source https://nuget.pkg.github.com/richlander/index.json
```