### PR TITLE
Convert SupportedOsGenerator to Markout template engine

### DIFF
--- a/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
+++ b/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="MarkdownTable.Formatting" Version="0.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="supported-os-template.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dotnet.Release.Tools.SupportedOs/SupportedOsGenerator.cs
+++ b/src/Dotnet.Release.Tools.SupportedOs/SupportedOsGenerator.cs
@@ -1,128 +1,72 @@
-using System.Text.Json;
 using Dotnet.Release.Support;
 using Markout;
+using Markout.Templates;
+using MarkdownTable.Formatting;
 
 namespace Dotnet.Release.Tools.SupportedOs;
 
 /// <summary>
-/// Generates supported-os.md from supported-os.json using Markout's MarkdownWriter.
+/// Generates supported-os.md from supported-os.json using a Markout template.
 /// </summary>
 public static class SupportedOsGenerator
 {
     public static async Task GenerateAsync(SupportedOSMatrix matrix, TextWriter output, string version, HttpClient client, string? supportPhase = null, string? releaseType = null)
     {
-        var writer = new MarkdownWriter();
-        int linkIndex = 0;
-        List<List<string>> allFamilyLinkDefs = [];
+        var template = MarkoutTemplate.Load(
+            Path.Combine(AppContext.BaseDirectory, "supported-os-template.md"));
+        template.TableOptions = new TableFormatterOptions();
 
-        // Title
-        writer.WriteHeading(1, $".NET {version} - Supported OS versions");
-        writer.WriteParagraph($"Last Updated: {matrix.LastUpdated:yyyy/MM/dd}; Support phase: {supportPhase ?? "Unknown"}");
-        writer.WriteParagraph($"[.NET {version}](README.md) is an [{releaseType ?? "Unknown"}](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.");
+        // Inline bindings
+        template.Bind("version", version);
+        template.Bind("lastUpdated", matrix.LastUpdated.ToString("yyyy/MM/dd"));
+        template.Bind("supportPhase", supportPhase ?? "Unknown");
+        template.Bind("releaseType", releaseType ?? "Unknown");
 
-        // Family sections
-        foreach (var family in matrix.Families)
-        {
-            List<string> familyLinkDefs = [];
-            List<string> notes = [];
+        // Families block binding (includes H2 headings per family)
+        var familiesBinding = new FamiliesBinding(matrix.Families);
+        template.Bind("families", familiesBinding);
 
-            writer.WriteHeading(2, family.Name);
-            writer.WriteTableStart("OS", "Versions", "Architectures", "Lifecycle");
-
-            foreach (var distro in family.Distributions)
-            {
-                IList<string> distroVersions = distro.Name == "Windows"
-                    ? WindowsVersionHelper.SimplifyVersions(distro.SupportedVersions)
-                    : distro.SupportedVersions;
-
-                string versions = distroVersions.Count == 0
-                    ? "[None](#out-of-support-os-versions)"
-                    : string.Join(", ", distroVersions);
-
-                string distroCell = $"[{distro.Name}][{linkIndex}]";
-                familyLinkDefs.Add($"[{linkIndex}]: {distro.Link}");
-                linkIndex++;
-
-                string lifecycleCell = distro.Lifecycle is null
-                    ? "None"
-                    : $"[Lifecycle][{linkIndex}]";
-                if (distro.Lifecycle is not null)
-                {
-                    familyLinkDefs.Add($"[{linkIndex}]: {distro.Lifecycle}");
-                    linkIndex++;
-                }
-
-                writer.WriteTableRow(distroCell, versions, string.Join(", ", distro.Architectures), lifecycleCell);
-
-                if (distro.Notes is { Count: > 0 })
-                {
-                    foreach (var note in distro.Notes)
-                        notes.Add($"{distro.Name}: {note}");
-                }
-            }
-
-            writer.WriteTableEnd();
-
-            if (notes.Count > 0)
-            {
-                writer.WriteParagraph("Notes:");
-                writer.WriteList(notes);
-            }
-
-            allFamilyLinkDefs.Add(familyLinkDefs);
-        }
-
-        // Libc section
+        // Libc conditional + block
         if (matrix.Libc is { Count: > 0 })
-        {
-            writer.WriteHeading(2, "Libc");
-            writer.WriteTableStart("Libc", "Version", "Architectures", "Source");
+            template.Bind("libc", new LibcBinding(matrix.Libc));
 
-            foreach (var libc in matrix.Libc)
-                writer.WriteTableRow(libc.Name, libc.Version, string.Join(", ", libc.Architectures), libc.Source);
-
-            writer.WriteTableEnd();
-        }
-
-        // Notes section
+        // Notes conditional + block
         if (matrix.Notes is { Count: > 0 })
-        {
-            writer.WriteHeading(2, "Notes");
-            writer.WriteList(matrix.Notes);
-        }
+            template.Bind("notes", new NotesBinding(matrix.Notes));
 
-        // Out of support OS versions section
-        await WriteUnsupportedSectionAsync(writer, matrix.Families, client);
+        // Unsupported section (requires async data fetch)
+        var unsupportedBinding = await CreateUnsupportedBindingAsync(matrix.Families, client);
+        if (unsupportedBinding is not null)
+            template.Bind("unsupported", unsupportedBinding);
 
-        // Write markdown content
-        output.Write(writer.ToString());
+        // Render through MarkdownWriter
+        var options = new MarkoutWriterOptions { PrettyTables = true };
+        template.SkipUnboundPlaceholders = true;
+        output.Write(template.Render(options));
 
-        // Append reference link definitions
-        if (allFamilyLinkDefs.Any(d => d.Count > 0))
+        // Append reference link definitions (outside the writer pipeline)
+        var linkDefs = familiesBinding.GetLinkDefinitions();
+        if (linkDefs.Count > 0)
         {
             output.WriteLine();
-            foreach (var familyDefs in allFamilyLinkDefs)
-            {
-                foreach (var def in familyDefs)
-                    output.WriteLine(def);
-            }
+            foreach (var def in linkDefs)
+                output.WriteLine(def);
         }
     }
 
-    private static async Task WriteUnsupportedSectionAsync(MarkdownWriter writer, IList<SupportFamily> families, HttpClient client)
+    private static async Task<UnsupportedBinding?> CreateUnsupportedBindingAsync(
+        IList<SupportFamily> families, HttpClient client)
     {
-        // Collect all unsupported versions across families
         var unsupportedEntries = families
             .SelectMany(f => f.Distributions
                 .SelectMany(d => (d.UnsupportedVersions ?? [])
                     .Select(v => (Distribution: d, Version: v))));
 
         if (!unsupportedEntries.Any())
-            return;
+            return null;
 
         Console.Error.WriteLine("Getting EoL data...");
 
-        // Fetch EOL data in parallel
         var eolResults = await Task.WhenAll(unsupportedEntries.Select(async entry =>
         {
             SupportCycle? cycle = null;
@@ -139,24 +83,10 @@ public static class SupportedOsGenerator
 
         var ordered = eolResults
             .OrderBy(e => e.Distribution.Name)
-            .ThenByDescending(e => e.Cycle?.GetSupportInfo().EolDate ?? DateOnly.MinValue);
+            .ThenByDescending(e => e.Cycle?.GetSupportInfo().EolDate ?? DateOnly.MinValue)
+            .ToList();
 
-        writer.WriteHeading(2, "Out of support OS versions");
-        writer.WriteParagraph("OS versions that are out of support by the OS publisher are not tested or supported by .NET.");
-
-        writer.WriteTableStart("OS", "Version", "End of Life");
-
-        foreach (var entry in ordered)
-        {
-            var distroVersion = entry.Distribution.Name == "Windows"
-                ? WindowsVersionHelper.Prettify(entry.Version)
-                : entry.Version;
-
-            var eolText = FormatEolDate(entry.Cycle);
-            writer.WriteTableRow(entry.Distribution.Name, distroVersion, eolText);
-        }
-
-        writer.WriteTableEnd();
+        return new UnsupportedBinding(ordered);
     }
 
     private static string FormatEolDate(SupportCycle? cycle)
@@ -168,5 +98,120 @@ public static class SupportedOsGenerator
 
         var dateStr = info.EolDate == DateOnly.MaxValue ? "Active" : info.EolDate.ToString("yyyy-MM-dd");
         return cycle.Link is not null ? $"[{dateStr}]({cycle.Link})" : dateStr;
+    }
+
+    /// <summary>
+    /// Renders all OS family sections with H2 headings and tables.
+    /// </summary>
+    private class FamiliesBinding(IList<SupportFamily> families) : IMarkoutFormattable
+    {
+        private readonly List<string> _linkDefs = [];
+
+        public List<string> GetLinkDefinitions() => _linkDefs;
+
+        public void WriteTo(MarkoutWriter writer)
+        {
+            int linkIndex = 0;
+
+            foreach (var family in families)
+            {
+                List<string> notes = [];
+
+                writer.WriteHeading(2, family.Name);
+                writer.WriteTableStart("OS", "Versions", "Architectures", "Lifecycle");
+
+                foreach (var distro in family.Distributions)
+                {
+                    IList<string> distroVersions = distro.Name == "Windows"
+                        ? WindowsVersionHelper.SimplifyVersions(distro.SupportedVersions)
+                        : distro.SupportedVersions;
+
+                    string versions = distroVersions.Count == 0
+                        ? "[None](#out-of-support-os-versions)"
+                        : string.Join(", ", distroVersions);
+
+                    string distroCell = $"[{distro.Name}][{linkIndex}]";
+                    _linkDefs.Add($"[{linkIndex}]: {distro.Link}");
+                    linkIndex++;
+
+                    string lifecycleCell = distro.Lifecycle is null
+                        ? "None"
+                        : $"[Lifecycle][{linkIndex}]";
+                    if (distro.Lifecycle is not null)
+                    {
+                        _linkDefs.Add($"[{linkIndex}]: {distro.Lifecycle}");
+                        linkIndex++;
+                    }
+
+                    writer.WriteTableRow(distroCell, versions, string.Join(", ", distro.Architectures), lifecycleCell);
+
+                    if (distro.Notes is { Count: > 0 })
+                    {
+                        foreach (var note in distro.Notes)
+                            notes.Add($"{distro.Name}: {note}");
+                    }
+                }
+
+                writer.WriteTableEnd();
+
+                if (notes.Count > 0)
+                {
+                    writer.WriteParagraph("Notes:");
+                    writer.WriteList(notes);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the Libc table.
+    /// </summary>
+    private class LibcBinding(IList<SupportLibc> libc) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteTableStart("Libc", "Version", "Architectures", "Source");
+
+            foreach (var entry in libc)
+                writer.WriteTableRow(entry.Name, entry.Version, string.Join(", ", entry.Architectures), entry.Source);
+
+            writer.WriteTableEnd();
+        }
+    }
+
+    /// <summary>
+    /// Renders notes as a bullet list.
+    /// </summary>
+    private class NotesBinding(IList<string> notes) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteList(notes);
+        }
+    }
+
+    /// <summary>
+    /// Renders the out-of-support OS table.
+    /// </summary>
+    private class UnsupportedBinding(
+        List<(SupportDistribution Distribution, string Version, SupportCycle? Cycle)> entries)
+        : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteTableStart("OS", "Version", "End of Life");
+
+            foreach (var entry in entries)
+            {
+                var distroVersion = entry.Distribution.Name == "Windows"
+                    ? WindowsVersionHelper.Prettify(entry.Version)
+                    : entry.Version;
+
+                var eolText = FormatEolDate(entry.Cycle);
+                writer.WriteTableRow(entry.Distribution.Name, distroVersion, eolText);
+            }
+
+            writer.WriteTableEnd();
+        }
     }
 }

--- a/src/Dotnet.Release.Tools.SupportedOs/supported-os-template.md
+++ b/src/Dotnet.Release.Tools.SupportedOs/supported-os-template.md
@@ -1,0 +1,27 @@
+# .NET {{version}} - Supported OS versions
+
+Last Updated: {{lastUpdated}}; Support phase: {{supportPhase}}
+
+[.NET {{version}}](README.md) is an [{{releaseType}}](../../release-policies.md) release and [is supported](../../support.md) on multiple operating systems per their lifecycle policy.
+
+{{families}}
+
+{{#if libc}}
+## Libc
+
+{{libc}}
+{{/if}}
+
+{{#if notes}}
+## Notes
+
+{{notes}}
+{{/if}}
+
+{{#if unsupported}}
+## Out of support OS versions
+
+OS versions that are out of support by the OS publisher are not tested or supported by .NET.
+
+{{unsupported}}
+{{/if}}


### PR DESCRIPTION
First consumer of the `Markout.Templates` library.

## Changes

Replaces the imperative `MarkdownWriter` code in `SupportedOsGenerator` with a `supported-os-template.md` file + typed `IMarkoutFormattable` bindings.

**Before:** ~170 lines of interleaved logic and writer calls
**After:** 27-line template file + focused binding classes

### Template (`supported-os-template.md`)

```markdown
# .NET {{version}} - Supported OS versions

Last Updated: {{lastUpdated}}; Support phase: {{supportPhase}}

[.NET {{version}}](README.md) is an [{{releaseType}}](../../release-policies.md) release ...

{{families}}

{{#if libc}}
## Libc
{{libc}}
{{/if}}

{{#if unsupported}}
## Out of support OS versions
{{unsupported}}
{{/if}}
```

### Bindings

| Binding | Type | Renders |
|---------|------|---------|
| `families` | `FamiliesBinding` | H2 + table per OS family, collects reference links |
| `libc` | `LibcBinding` | Libc requirements table |
| `notes` | `NotesBinding` | Bullet list |
| `unsupported` | `UnsupportedBinding` | Out-of-support OS table (async EOL data) |

### Output

Structurally identical to the previous version. The only visible difference is that tables now have aligned columns thanks to `PrettyTables` and `TableFormatterOptions`.