### PR TITLE
Embed template as resource with export and override support

### DIFF
--- a/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
+++ b/src/Dotnet.Release.Tools.SupportedOs/Dotnet.Release.Tools.SupportedOs.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="supported-os-template.md" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="supported-os-template.md" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Makes the AOT single-file tool self-contained by embedding the template as a resource instead of copying it alongside the binary.

## New commands

```bash
# Export the built-in template for customization
dotnet-supported-os --export-template > my-template.md

# Use a customized template
dotnet-supported-os 10.0 --template my-template.md

# Default behavior unchanged — uses embedded template
dotnet-supported-os 10.0 ~/git/core/release-notes
```

## Changes

- `supported-os-template.md`: `Content` → `EmbeddedResource`
- `SupportedOsGenerator.LoadTemplate(path?)`: loads from file or embedded resource
- `SupportedOsGenerator.ExportTemplate(writer)`: writes built-in template to a stream
- `Program.cs`: `--export-template` and `--template <file>` argument handling