### PR TITLE
Use native ARM64 runner for linux-arm64 AOT build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           - rid: linux-x64
             os: ubuntu-latest
           - rid: linux-arm64
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
           - rid: osx-arm64
             os: macos-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The linux-arm64 AOT build fails on `ubuntu-latest` (x64) because the linker can't target aarch64:

```
/usr/bin/ld.bfd: unrecognised emulation mode: aarch64linux
```

Switch to `ubuntu-24.04-arm` (native ARM64 runner), matching the approach used by dotnet-inspect.