### PR TITLE
Add Tools section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Tools are published as [RID-specific NuGet tool packages](https://learn.microsof
 Install from [GitHub Packages](https://github.com/richlander/dotnet-release/pkgs/nuget):
 
 ```bash
-# Add the GitHub Packages source (uses gh CLI for authentication)
+# Add the GitHub Packages source (using gh CLI for authentication)
 dotnet nuget add source https://nuget.pkg.github.com/richlander/index.json --name richlander --username $(gh api user --jq .login) --password $(gh auth token)
+
+# Or manually with a personal access token
+dotnet nuget add source https://nuget.pkg.github.com/richlander/index.json --name richlander --username <GITHUB_USERNAME> --password <GITHUB_TOKEN>
 ```
 
 Install tools globally:


### PR DESCRIPTION
Adds a Tools section documenting how to install RID-specific AOT tool packages from GitHub Packages. Currently lists `dotnet-supported-os`; table is easy to extend as more tools are added.