### PR TITLE
Add distro-packages query tool and skills

### DIFF
--- a/skills/update-distro-packages/SKILL.md
+++ b/skills/update-distro-packages/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: update-distro-packages
+description: Generate and update distro-packages.json files documenting which .NET packages are available in each Linux distribution's native archive and the Microsoft feed, for a given .NET version.
+---
+
+# Update Distro Packages
+
+Generate and update `distro-packages.json` files that document which .NET packages (SDK, runtime, ASP.NET Core runtime, etc.) are available in each Linux distribution, across multiple package feeds.
+
+## When to use
+
+- A new .NET version is released and you need to document which distros carry it
+- A distro ships or drops a .NET version in their archive
+- Periodic audit to keep the availability data current
+- You want to understand where users can get .NET packages for a specific distro+version combination
+
+## Background
+
+.NET packages come from multiple sources per distribution:
+
+- **Built-in feed** — the distro's own archive (e.g. `apt install dotnet-sdk-9.0` on Ubuntu)
+- **Backports feed** — newer versions backported to LTS distros (Ubuntu-specific)
+- **Microsoft feed** — packages.microsoft.com, available for many distros but being phased out for newer Ubuntu/Fedora
+- **Community feed** — community-maintained packages (Alpine `community` repo)
+
+Package naming varies by distro:
+- Debian/Ubuntu/Fedora: `dotnet-sdk-9.0`, `dotnet-runtime-9.0`, `aspnetcore-runtime-9.0`
+- Alpine: `dotnet9-sdk`, `dotnet9-runtime`
+
+## Prerequisites
+
+Install the `dotnet-release` tool (see [README](../../README.md) for NuGet source setup):
+
+```bash
+dotnet tool install -g Dotnet.Release.Tools
+```
+
+## Inputs
+
+The user provides:
+- **dotnet/core path** — local path to the dotnet/core repo (e.g. `~/git/core`)
+- **.NET version** — which version to audit (e.g. "9.0")
+- Optionally, specific distros to focus on
+
+## Process
+
+### 1. Determine scope
+
+Read `release-notes/{version}/supported-os.json` to get the list of supported Linux distributions and versions.
+
+### 2. Query package feeds
+
+Run `dotnet-release query distro-packages {version}` to check each feed. The tool uses the feed URLs from the embedded `distro-sources.json` to:
+
+1. For each distro+version, check the built-in/community feed for .NET SDK, runtime, and ASP.NET Core runtime packages
+2. Check the Microsoft feed (packages.microsoft.com) where applicable
+3. For Ubuntu, also check the backports feed
+4. Collect package names, versions, and architectures
+
+### 3. Review results
+
+Present the findings to the user as a summary table showing:
+- Which .NET components are available per distro+version
+- Which feed(s) they come from
+- Any gaps (supported distro but no packages available)
+
+### 4. Generate output
+
+Write `distro-packages.json` to `release-notes/{version}/` in the dotnet/core repo. The file follows the `DistroPackagesOverview` schema with per-feed package listings.
+
+### 5. Cross-reference with docs
+
+Compare results against the install documentation in `dotnet/docs` (e.g. `docs/core/install/linux-ubuntu-install.md`) which maintains availability tables per distro. Flag any discrepancies between what the feeds actually contain and what the docs claim.
+
+### 6. Verify and commit
+
+1. Validate the generated JSON parses correctly
+2. Show the user a summary of the generated file
+3. On confirmation, commit with a descriptive message
+
+## Key facts
+
+- Microsoft is phasing out packages.microsoft.com for Ubuntu 24.04+ and newer Fedora — those distros ship .NET in their own archives
+- Ubuntu 22.04 is the last Ubuntu version with Microsoft feed packages
+- Alpine packages are in the `community` repo, not `main`
+- Alpine uses a different naming scheme: `dotnet{major}-{component}` (e.g. `dotnet9-sdk`)
+- The `dotnet/docs` repo (`~/git/docs`) has authoritative availability tables in `docs/core/install/linux-*.md`
+- Package versions in distro feeds may lag behind the latest .NET patch release

--- a/skills/update-os-packages/SKILL.md
+++ b/skills/update-os-packages/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: update-os-packages
+description: Audit and update os-packages.json files in dotnet/core to ensure Linux distribution package names are correct. Verifies package names against upstream package repositories and fixes mismatches.
+---
+
+# Update OS Packages
+
+Audit and update `os-packages.json` files in the [dotnet/core](https://github.com/dotnet/core) repository. These files declare the Linux distribution packages required to run .NET on each supported distro release.
+
+## When to use
+
+- A new distro version is released (e.g. Ubuntu 26.04, Alpine 3.23) and packages need to be added or verified
+- Package names may have changed upstream (e.g. `libicu76` → `libicu78`)
+- Periodic audit to ensure all listed package names are still correct
+
+## Prerequisites
+
+Install the `dotnet-release` tool (see [README](../../README.md) for NuGet source setup):
+
+```bash
+dotnet tool install -g Dotnet.Release.Tools
+```
+
+## Inputs
+
+The user provides:
+- **dotnet/core path** — local path to the dotnet/core repo (e.g. `~/git/core`)
+- **Versions to audit** — which .NET versions to check (e.g. "8.0+", "10.0 only"), defaults to all active versions
+
+## Process
+
+### 1. Identify scope
+
+Determine which .NET versions to audit. Active versions are those with `os-packages.json` files in the `release-notes/` directory. Skip versions the user excludes.
+
+For each version, read `release-notes/{version}/os-packages.json`.
+
+### 2. Verify package names
+
+Run the `dotnet-release verify os-packages` command for each version. The tool checks each package name against upstream distro package feeds and reports mismatches.
+
+### 3. Cross-reference with supported-os.json
+
+For each version, read `release-notes/{version}/supported-os.json` and check:
+- Every Linux distro+version in `supported-os.json` has a matching entry in `os-packages.json`
+- No distro+version in `os-packages.json` is absent from `supported-os.json` (stale entries)
+
+Report gaps to the user. **Do not add new distro entries automatically** — the user decides whether to add them.
+
+### 4. Apply fixes
+
+For confirmed mismatches (wrong package names):
+- Update the package name in os-packages.json across **all** affected .NET versions (the same distro release uses the same packages regardless of .NET version)
+- Use the `edit` tool to make surgical changes
+
+### 5. Verify and commit
+
+1. Validate all modified JSON files parse correctly (use a file-based app to deserialize with `Dotnet.Release.Support` types)
+2. Show the user a summary of changes
+3. On confirmation, commit with a descriptive message
+
+## Key facts
+
+- Package names like `libicu` are versioned on Debian/Ubuntu (e.g. `libicu76`) but **not** on Fedora/RHEL/SUSE (just `libicu`)
+- OpenSSL on Debian 13+ and Ubuntu 24.04+ uses the `t64` suffix (`libssl3t64`)
+- Alpine uses different package names entirely (`icu-libs`, `libssl3`, `krb5`)
+- The same distro release always has the same packages regardless of .NET version — fixes should be applied across all os-packages.json files

--- a/skills/update-supported-os/SKILL.md
+++ b/skills/update-supported-os/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: update-supported-os
+description: Audit and update supported-os.json files in dotnet/core to reflect current OS version support. Checks upstream distro lifecycle data to add new releases and retire end-of-life versions.
+---
+
+# Update Supported OS
+
+Audit and update `supported-os.json` files in the [dotnet/core](https://github.com/dotnet/core) repository. These files declare which operating system versions are supported for each .NET release.
+
+## When to use
+
+- A new OS version is released (e.g. Ubuntu 26.04, Fedora 44, Alpine 3.23)
+- An OS version reaches end-of-life and should be moved to unsupported
+- Periodic audit to ensure the support matrix is current
+
+## Prerequisites
+
+Install the `dotnet-release` tool (see [README](../../README.md) for NuGet source setup):
+
+```bash
+dotnet tool install -g Dotnet.Release.Tools
+```
+
+## Inputs
+
+The user provides:
+- **dotnet/core path** — local path to the dotnet/core repo (e.g. `~/git/core`)
+- **Versions to audit** — which .NET versions to check (e.g. "8.0+", "10.0 only"), defaults to all active versions
+- Optionally, specific distros or OS versions to focus on
+
+## Process
+
+### 1. Identify scope
+
+Determine which .NET versions to audit. For each version, read `release-notes/{version}/supported-os.json`.
+
+### 2. Check upstream lifecycle data
+
+For each Linux distribution in the support matrix:
+
+1. Query [endoflife.date](https://endoflife.date/api/{distro-id}.json) using `web_fetch` to get current lifecycle data
+2. Compare against what's listed in supported-os.json
+3. Identify:
+   - **New releases** — versions that exist upstream but aren't in supported-os.json
+   - **EOL versions** — versions listed as supported that have reached end-of-life
+   - **Upcoming EOL** — versions approaching end-of-life (informational)
+
+The `id` field in each distribution entry matches the endoflife.date product ID (e.g. `alpine`, `ubuntu`, `debian`, `fedora`, `rhel`).
+
+### 3. Determine .NET version applicability
+
+Not every OS release applies to every .NET version:
+- **LTS .NET versions** (8.0, 10.0) support a broader set of OS versions
+- **STS .NET versions** (9.0, 11.0) have a shorter support window
+- New OS versions are typically only added to .NET versions still in active support
+- Check the .NET version's own support status before adding OS versions to it
+
+Present findings to the user with recommendations, grouped by action type.
+
+### 4. Apply changes
+
+On user confirmation:
+
+- **Add new supported versions**: Insert into the `supported-versions` array (keep sorted, newest first)
+- **Retire EOL versions**: Move from `supported-versions` to `unsupported-versions`
+- **Update `last-updated`**: Set to today's date
+- Use the `edit` tool for surgical JSON changes
+
+### 5. Cross-reference with os-packages.json
+
+After updating supported-os.json, check if any newly added distro versions need entries in os-packages.json. If so, inform the user to run the `update-os-packages` skill next.
+
+### 6. Verify and commit
+
+1. Validate all modified JSON files parse correctly (use a file-based app to deserialize with `Dotnet.Release.Support` types)
+2. Regenerate the supported-os.md if the `dotnet-release` tool is available:
+   ```bash
+   dotnet-release generate supported-os {version} {core-path}/release-notes
+   ```
+3. Show the user a summary of changes
+4. On confirmation, commit with a descriptive message
+
+## Key facts
+
+- The `id` field in each distribution matches [endoflife.date](https://endoflife.date) product IDs
+- Versions are strings, not numbers — `"3.22"` not `3.22`
+- `supported-versions` should be ordered newest-first
+- `unsupported-versions` tracks previously-supported versions for historical reference
+- Non-Linux OS families (Android, Apple, Windows) follow the same structure but use different lifecycle sources
+- The `last-updated` field should reflect the date of any change

--- a/src/Dotnet.Release.Support/DistroPackages.cs
+++ b/src/Dotnet.Release.Support/DistroPackages.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Support;
+
+// For distro-packages.json — documents which .NET packages are available
+// in each Linux distribution for a given .NET version, from both the
+// distribution's native archive and the Microsoft (packages.microsoft.com) feed.
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Skip)]
+[Description("Availability of .NET packages in Linux distribution archives for a given .NET version.")]
+public record DistroPackagesOverview(
+    [property: Description("Major.minor version of .NET (e.g. '9.0').")]
+    string ChannelVersion,
+
+    [property: Description("Date when this file was last verified.")]
+    DateOnly LastVerified,
+
+    [property: Description(".NET component packages to look for in each distribution.")]
+    IList<DotnetComponent> Components,
+
+    [property: Description("Distributions and which .NET packages they offer.")]
+    IList<DistroPackageAvailability> Distributions);
+
+[Description("A .NET component that may be packaged by distributions.")]
+public record DotnetComponent(
+    [property: Description("Component identifier (e.g. 'sdk', 'runtime', 'aspnetcore-runtime').")]
+    string Id,
+
+    [property: Description("Display name.")]
+    string Name);
+
+[Description("A distribution and its available .NET packages.")]
+public record DistroPackageAvailability(
+    [property: Description("Distribution name, matching os-packages.json and supported-os.json.")]
+    string Name,
+
+    [property: Description("Releases of this distribution with .NET package availability.")]
+    IList<DistroReleasePackages> Releases);
+
+[Description("A distribution release and which .NET packages it offers.")]
+public record DistroReleasePackages(
+    [property: Description("Display name for the release.")]
+    string Name,
+
+    [property: Description("Version string for the release.")]
+    string Release,
+
+    [property: Description(".NET packages by feed name (e.g. 'builtin', 'backports', 'microsoft'). Each feed maps to a list of available packages.")]
+    IDictionary<string, IList<DotnetDistroPackage>>? Feeds = null);
+
+[Description("A .NET package available in a package archive.")]
+public record DotnetDistroPackage(
+    [property: Description("Component ID (e.g. 'sdk', 'runtime').")]
+    string ComponentId,
+
+    [property: Description("Package name in the archive.")]
+    string PackageName,
+
+    [property: Description("Package version string from the archive.")]
+    string? Version = null,
+
+    [property: Description("Architectures the package is available for.")]
+    IList<string>? Architectures = null,
+
+    [property: Description("Repository within the distribution (e.g. 'main', 'universe', 'community').")]
+    string? Repository = null);

--- a/src/Dotnet.Release.Support/DistroSources.cs
+++ b/src/Dotnet.Release.Support/DistroSources.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Support;
+
+[Description("Collection of distribution package source metadata.")]
+public record DistroSourceCollection(
+    [property: Description("Distribution package sources.")]
+    IList<DistroSource> Sources);
+
+[Description("A supplemental .NET package feed not covered by pkgs.org.")]
+public record DotnetFeed(
+    [property: Description("Feed checker type (e.g. 'launchpad', 'brew_formula', 'nixpkgs_github').")]
+    string Type,
+
+    [property: Description("URL template for the feed. Supports {major}, {minor}, {version}, {codename} placeholders.")]
+    string Url);
+
+[Description("Package source metadata for a Linux distribution family.")]
+public record DistroSource(
+    [property: Description("Name of the distribution.")]
+    string Name,
+
+    [property: Description("Docker image template. Supports {version} and {codename} placeholders.")]
+    string? DockerImage = null)
+{
+    [Description("Product ID on endoflife.date (e.g. 'ubuntu', 'alpine', 'fedora').")]
+    public string? EndoflifeId { get; init; }
+
+    [Description("Map of version numbers to distribution codenames (e.g. '24.04' -> 'noble').")]
+    public IDictionary<string, string>? Codenames { get; init; }
+
+    [Description("Package naming pattern for .NET packages (e.g. 'dotnet-{component}-{major}.{minor}').")]
+    public string? DotnetPackagePattern { get; init; }
+
+    [Description("Supplemental .NET package feeds not covered by pkgs.org (e.g. Ubuntu backports PPA, Homebrew, NixOS).")]
+    public IDictionary<string, DotnetFeed>? DotnetFeeds { get; init; }
+
+    /// <summary>
+    /// Resolves a Docker image name for the given version.
+    /// </summary>
+    public string? GetDockerImageName(string version)
+    {
+        if (DockerImage is null) return null;
+        string image = DockerImage.Replace("{version}", version);
+
+        if (Codenames is not null && Codenames.TryGetValue(version, out string? codename))
+        {
+            image = image.Replace("{codename}", codename);
+        }
+
+        return image;
+    }
+
+    /// <summary>
+    /// Returns the codename for a version, or null if not mapped.
+    /// </summary>
+    public string? GetCodename(string version) =>
+        Codenames is not null && Codenames.TryGetValue(version, out string? codename) ? codename : null;
+
+    /// <summary>
+    /// Resolves a feed URL template with version/codename/dotnet version placeholders.
+    /// </summary>
+    public static string ResolveFeedUrl(string urlTemplate, string? distroVersion, string? codename, string dotnetMajor, string dotnetMinor)
+    {
+        string url = urlTemplate
+            .Replace("{major}", dotnetMajor)
+            .Replace("{minor}", dotnetMinor);
+
+        if (distroVersion is not null)
+            url = url.Replace("{version}", distroVersion);
+        if (codename is not null)
+            url = url.Replace("{codename}", codename);
+
+        return url;
+    }
+
+    /// <summary>
+    /// Loads the embedded distro-sources.json.
+    /// </summary>
+    public static DistroSourceCollection Load()
+    {
+        const string resourceName = "Dotnet.Release.Support.distro-sources.json";
+        using var stream = typeof(DistroSource).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource not found: {resourceName}");
+        return JsonSerializer.Deserialize(stream, DistroSourceSerializerContext.Default.DistroSourceCollection)
+            ?? throw new InvalidOperationException("Failed to deserialize distro-sources.json");
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(DistroSourceCollection))]
+public partial class DistroSourceSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Support/Dotnet.Release.Support.csproj
+++ b/src/Dotnet.Release.Support/Dotnet.Release.Support.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="distro-sources.json" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dotnet.Release.Support/PkgsOrg.cs
+++ b/src/Dotnet.Release.Support/PkgsOrg.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Support;
+
+// Models for the pkgs.org API (https://pkgs.org/api/)
+// Requires Gold+ subscription. Token via PKGS_ORG_TOKEN env var.
+
+[Description("A distribution on pkgs.org.")]
+public record PkgsOrgDistribution(
+    [property: JsonPropertyName("id")]
+    int Id,
+
+    [property: JsonPropertyName("name")]
+    string Name,
+
+    [property: JsonPropertyName("version")]
+    string Version);
+
+[Description("A repository on pkgs.org.")]
+public record PkgsOrgRepository(
+    [property: JsonPropertyName("id")]
+    int Id,
+
+    [property: JsonPropertyName("distribution_id")]
+    int DistributionId,
+
+    [property: JsonPropertyName("name")]
+    string Name,
+
+    [property: JsonPropertyName("architecture")]
+    string Architecture,
+
+    [property: JsonPropertyName("official")]
+    bool Official);
+
+[Description("A package search result from pkgs.org.")]
+public record PkgsOrgPackage(
+    [property: JsonPropertyName("filename")]
+    string Filename,
+
+    [property: JsonPropertyName("filename_src")]
+    string? FilenameSrc,
+
+    [property: JsonPropertyName("name")]
+    string Name,
+
+    [property: JsonPropertyName("epoch")]
+    int? Epoch,
+
+    [property: JsonPropertyName("version")]
+    string Version,
+
+    [property: JsonPropertyName("release")]
+    string? Release,
+
+    [property: JsonPropertyName("architecture")]
+    string Architecture,
+
+    [property: JsonPropertyName("url_binary")]
+    string? UrlBinary,
+
+    [property: JsonPropertyName("url_source")]
+    string? UrlSource)
+{
+    [JsonPropertyName("distribution_id")]
+    public int DistributionId { get; init; }
+
+    [JsonPropertyName("repository_id")]
+    public int RepositoryId { get; init; }
+}
+
+[JsonSerializable(typeof(IList<PkgsOrgDistribution>))]
+[JsonSerializable(typeof(IList<PkgsOrgRepository>))]
+[JsonSerializable(typeof(IList<PkgsOrgPackage>))]
+public partial class PkgsOrgSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Support/PkgsOrgClient.cs
+++ b/src/Dotnet.Release.Support/PkgsOrgClient.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Dotnet.Release.Support;
+
+/// <summary>
+/// Client for the pkgs.org API (https://pkgs.org/api/).
+/// Requires Gold+ subscription. Set PKGS_ORG_TOKEN environment variable.
+/// </summary>
+public sealed class PkgsOrgClient : IDisposable
+{
+    private const string BaseUrl = "https://api.pkgs.org/v1";
+    private readonly HttpClient _client;
+    private readonly bool _ownsClient;
+
+    public PkgsOrgClient(string accessToken, HttpClient? client = null)
+    {
+        _ownsClient = client is null;
+        _client = client ?? new HttpClient();
+        _client.DefaultRequestHeaders.Add("Cookie", $"access_token={accessToken}");
+    }
+
+    /// <summary>
+    /// Returns all distributions known to pkgs.org.
+    /// </summary>
+    public async Task<IList<PkgsOrgDistribution>> GetDistributionsAsync()
+    {
+        return await GetAsync($"{BaseUrl}/distributions", PkgsOrgSerializerContext.Default.IListPkgsOrgDistribution)
+            ?? [];
+    }
+
+    /// <summary>
+    /// Returns all repositories known to pkgs.org.
+    /// </summary>
+    public async Task<IList<PkgsOrgRepository>> GetRepositoriesAsync()
+    {
+        return await GetAsync($"{BaseUrl}/repositories", PkgsOrgSerializerContext.Default.IListPkgsOrgRepository)
+            ?? [];
+    }
+
+    /// <summary>
+    /// Searches for packages matching the query across all distros.
+    /// </summary>
+    public async Task<IList<PkgsOrgPackage>> SearchAsync(
+        string query,
+        bool? official = null,
+        string? architecture = null,
+        IEnumerable<int>? distributions = null,
+        IEnumerable<int>? repositories = null)
+    {
+        var url = $"{BaseUrl}/search?query={Uri.EscapeDataString(query)}";
+
+        if (official.HasValue)
+            url += $"&official={official.Value.ToString().ToLowerInvariant()}";
+        if (architecture is not null)
+            url += $"&architecture={Uri.EscapeDataString(architecture)}";
+        if (distributions is not null)
+            url += $"&distributions={string.Join(",", distributions)}";
+        if (repositories is not null)
+            url += $"&repositories={string.Join(",", repositories)}";
+
+        return await GetAsync(url, PkgsOrgSerializerContext.Default.IListPkgsOrgPackage)
+            ?? [];
+    }
+
+    /// <summary>
+    /// Searches for .NET SDK/runtime/aspnetcore packages for a given .NET major version.
+    /// Returns results grouped by package name.
+    /// </summary>
+    public async Task<IList<PkgsOrgPackage>> SearchDotnetAsync(string dotnetMajorMinor, string? architecture = "intel")
+    {
+        // Search broadly for "dotnet" packages matching this version
+        // Different distros use different naming: dotnet-sdk-9.0, dotnet9-sdk, etc.
+        var results = new List<PkgsOrgPackage>();
+
+        // Search for the common naming patterns
+        string major = dotnetMajorMinor.Split('.')[0];
+        string[] queries = [$"dotnet-sdk-{dotnetMajorMinor}", $"dotnet{major}-sdk", $"dotnet-runtime-{dotnetMajorMinor}", $"dotnet{major}-runtime"];
+
+        foreach (var query in queries)
+        {
+            var packages = await SearchAsync(query, official: true, architecture: architecture);
+            results.AddRange(packages);
+            await Task.Delay(200); // Rate limiting
+        }
+
+        return results;
+    }
+
+    private async Task<T?> GetAsync<T>(string url, JsonTypeInfo<T> typeInfo)
+    {
+        using var response = await _client.GetAsync(url);
+
+        if (response.StatusCode == HttpStatusCode.PaymentRequired)
+            throw new InvalidOperationException("pkgs.org API requires Gold+ subscription. Check your PKGS_ORG_TOKEN.");
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+            throw new InvalidOperationException("Invalid pkgs.org API token. Set PKGS_ORG_TOKEN environment variable.");
+
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync(typeInfo);
+    }
+
+    public void Dispose()
+    {
+        if (_ownsClient) _client.Dispose();
+    }
+}

--- a/src/Dotnet.Release.Support/SupportSerializerContexts.cs
+++ b/src/Dotnet.Release.Support/SupportSerializerContexts.cs
@@ -17,3 +17,11 @@ public partial class OSPackagesSerializerContext : JsonSerializerContext
 public partial class SupportedOSMatrixSerializerContext : JsonSerializerContext
 {
 }
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(DistroPackagesOverview))]
+public partial class DistroPackagesSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Support/distro-sources.json
+++ b/src/Dotnet.Release.Support/distro-sources.json
@@ -1,0 +1,105 @@
+{
+  "sources": [
+    {
+      "name": "Ubuntu",
+      "endoflife_id": "ubuntu",
+      "codenames": {
+        "26.04": "resolute",
+        "25.10": "questing",
+        "25.04": "plucky",
+        "24.04": "noble",
+        "22.04": "jammy"
+      },
+      "docker_image": "ubuntu:{version}",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}",
+      "dotnet_feeds": {
+        "backports": {
+          "type": "launchpad",
+          "url": "https://api.launchpad.net/1.0/~dotnet/+archive/ubuntu/backports?ws.op=getPublishedSources&source_name=dotnet{major}&exact_match=false&distro_series=https://api.launchpad.net/1.0/ubuntu/{codename}&status=Published"
+        }
+      }
+    },
+    {
+      "name": "Alpine",
+      "endoflife_id": "alpine",
+      "docker_image": "alpine:{version}",
+      "dotnet_package_pattern": "dotnet{major}-{component}"
+    },
+    {
+      "name": "Fedora",
+      "endoflife_id": "fedora",
+      "docker_image": "fedora:{version}",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "RHEL",
+      "endoflife_id": "rhel",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "CentOS Stream",
+      "endoflife_id": "centos-stream",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "AlmaLinux",
+      "endoflife_id": "almalinux",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "Rocky Linux",
+      "endoflife_id": "rocky-linux",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "Oracle Linux",
+      "endoflife_id": "oracle-linux",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "Amazon Linux",
+      "endoflife_id": "amazon-linux",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "OpenMandriva",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "ALT Linux",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "Arch Linux",
+      "dotnet_package_pattern": "dotnet-{component}"
+    },
+    {
+      "name": "Wolfi",
+      "dotnet_package_pattern": "dotnet-{major}-{component}"
+    },
+    {
+      "name": "FreeBSD",
+      "endoflife_id": "freebsd",
+      "dotnet_package_pattern": "dotnet-{component}-{major}.{minor}"
+    },
+    {
+      "name": "Homebrew",
+      "dotnet_feeds": {
+        "core": {
+          "type": "brew_formula",
+          "url": "https://formulae.brew.sh/api/formula/dotnet@{major}.json"
+        }
+      }
+    },
+    {
+      "name": "NixOS",
+      "endoflife_id": "nixos",
+      "dotnet_feeds": {
+        "nixpkgs": {
+          "type": "nixpkgs_github",
+          "url": "https://api.github.com/repos/NixOS/nixpkgs/contents/pkgs/development/compilers/dotnet/{major}?ref=nixos-{version}"
+        }
+      }
+    }
+  ]
+}

--- a/src/Dotnet.Release.Tools/DistroPackagesGenerator.cs
+++ b/src/Dotnet.Release.Tools/DistroPackagesGenerator.cs
@@ -1,0 +1,432 @@
+using System.Text.Json;
+using Dotnet.Release.Support;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates distro-packages.json by querying pkgs.org + supplemental feeds.
+/// </summary>
+public static class DistroPackagesGenerator
+{
+    public static readonly DotnetComponent[] Components =
+    [
+        new("sdk", ".NET SDK"),
+        new("runtime", ".NET Runtime"),
+        new("aspnetcore-runtime", "ASP.NET Core Runtime"),
+    ];
+
+    /// <summary>
+    /// Queries all data sources and produces a DistroPackagesOverview for the given .NET version.
+    /// </summary>
+    public static async Task<DistroPackagesOverview> QueryAsync(
+        string dotnetVersion,
+        PkgsOrgClient pkgsOrg,
+        HttpClient http,
+        TextWriter log)
+    {
+        string[] parts = dotnetVersion.Split('.');
+        string major = parts[0];
+        string minor = parts.Length > 1 ? parts[1] : "0";
+
+        // Step 1: Get distro metadata from pkgs.org
+        log.WriteLine("Fetching pkgs.org distributions...");
+        var pkgsDistros = await pkgsOrg.GetDistributionsAsync();
+        log.WriteLine($"  {pkgsDistros.Count} distributions");
+
+        var pkgsRepos = await pkgsOrg.GetRepositoriesAsync();
+        log.WriteLine($"  {pkgsRepos.Count} repositories");
+
+        // Build lookup maps
+        var distroById = pkgsDistros.ToDictionary(d => d.Id);
+        var repoById = pkgsRepos.ToDictionary(r => r.Id);
+
+        // Step 2: Search pkgs.org for .NET packages
+        log.WriteLine($"\nSearching pkgs.org for .NET {dotnetVersion} packages...");
+        var pkgsResults = await SearchPkgsOrgAsync(pkgsOrg, major, minor, log);
+        log.WriteLine($"  {pkgsResults.Count} total package results");
+
+        // Step 3: Group results by distro
+        var pkgsGrouped = GroupByDistro(pkgsResults, distroById, repoById);
+
+        // Step 4: Load distro-sources.json for supplemental feeds + metadata
+        var distroSources = DistroSource.Load();
+
+        // Step 5: Check supplemental feeds (backports PPA, Homebrew, NixOS)
+        log.WriteLine("\nChecking supplemental feeds...");
+        var supplemental = await CheckSupplementalFeedsAsync(distroSources, dotnetVersion, major, minor, http, log);
+
+        // Step 6: Merge pkgs.org results + supplemental into output model
+        log.WriteLine("\nBuilding output...");
+        var distributions = MergeResults(pkgsGrouped, supplemental, distroSources);
+
+        return new DistroPackagesOverview(
+            dotnetVersion,
+            DateOnly.FromDateTime(DateTime.UtcNow),
+            [.. Components],
+            distributions);
+    }
+
+    static async Task<IList<PkgsOrgPackage>> SearchPkgsOrgAsync(
+        PkgsOrgClient pkgsOrg, string major, string minor, TextWriter log)
+    {
+        var allResults = new List<PkgsOrgPackage>();
+
+        // Search for common naming patterns across all distros
+        string[] queries =
+        [
+            $"dotnet-sdk-{major}.{minor}",
+            $"dotnet-runtime-{major}.{minor}",
+            $"aspnetcore-runtime-{major}.{minor}",
+            $"dotnet{major}-sdk",        // Alpine naming
+            $"dotnet{major}-runtime",    // Alpine naming
+            $"dotnet-sdk",               // Arch (unversioned)
+            $"dotnet-runtime",           // Arch (unversioned)
+            $"dotnet-{major}-sdk",       // Wolfi naming
+            $"dotnet-{major}-runtime",   // Wolfi naming
+        ];
+
+        foreach (var query in queries)
+        {
+            log.Write($"  Searching '{query}'... ");
+            var results = await pkgsOrg.SearchAsync(query, official: true, architecture: "intel");
+            log.WriteLine($"{results.Count} results");
+            allResults.AddRange(results);
+            await Task.Delay(300); // Rate limiting
+        }
+
+        return allResults;
+    }
+
+    /// <summary>
+    /// Groups pkgs.org results by "DistroName Version" → feed → packages.
+    /// </summary>
+    static Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> GroupByDistro(
+        IList<PkgsOrgPackage> packages,
+        Dictionary<int, PkgsOrgDistribution> distroById,
+        Dictionary<int, PkgsOrgRepository> repoById)
+    {
+        var grouped = new Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>>();
+
+        foreach (var pkg in packages)
+        {
+            if (!distroById.TryGetValue(pkg.DistributionId, out var distro))
+                continue;
+            if (!repoById.TryGetValue(pkg.RepositoryId, out var repo))
+                continue;
+
+            string distroKey = $"{distro.Name} {distro.Version}";
+            string? componentId = InferComponentId(pkg.Name);
+            if (componentId is null) continue;
+
+            if (!grouped.TryGetValue(distroKey, out var feeds))
+            {
+                feeds = [];
+                grouped[distroKey] = feeds;
+            }
+
+            string feedName = repo.Official ? "builtin" : "thirdparty";
+            if (!feeds.TryGetValue(feedName, out var feedPackages))
+            {
+                feedPackages = [];
+                feeds[feedName] = feedPackages;
+            }
+
+            // Avoid duplicates
+            if (feedPackages.Any(p => p.ComponentId == componentId)) continue;
+
+            feedPackages.Add(new DotnetDistroPackage(
+                componentId,
+                pkg.Name,
+                pkg.Version,
+                [pkg.Architecture],
+                repo.Name));
+        }
+
+        return grouped;
+    }
+
+    /// <summary>
+    /// Infers the .NET component ID from a package name.
+    /// </summary>
+    static string? InferComponentId(string packageName)
+    {
+        if (packageName.Contains("aspnetcore") || packageName.Contains("aspnet"))
+            return "aspnetcore-runtime";
+        if (packageName.Contains("sdk"))
+            return "sdk";
+        if (packageName.Contains("runtime"))
+            return "runtime";
+        return null;
+    }
+
+    /// <summary>
+    /// Checks supplemental feeds not covered by pkgs.org.
+    /// </summary>
+    static async Task<Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>>> CheckSupplementalFeedsAsync(
+        DistroSourceCollection distroSources,
+        string dotnetVersion,
+        string major,
+        string minor,
+        HttpClient http,
+        TextWriter log)
+    {
+        var results = new Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>>();
+
+        foreach (var source in distroSources.Sources)
+        {
+            if (source.DotnetFeeds is null) continue;
+
+            foreach (var (feedName, feed) in source.DotnetFeeds)
+            {
+                switch (feed.Type)
+                {
+                    case "launchpad":
+                        await CheckLaunchpadFeedAsync(source, feedName, feed, major, minor, http, log, results);
+                        break;
+                    case "brew_formula":
+                        await CheckBrewFormulaAsync(source, feedName, feed, major, minor, http, log, results);
+                        break;
+                    case "nixpkgs_github":
+                        await CheckNixpkgsAsync(source, feedName, feed, major, minor, http, log, results);
+                        break;
+                }
+            }
+        }
+
+        return results;
+    }
+
+    static async Task CheckLaunchpadFeedAsync(
+        DistroSource source, string feedName, DotnetFeed feed,
+        string major, string minor, HttpClient http, TextWriter log,
+        Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> results)
+    {
+        if (source.Codenames is null) return;
+
+        foreach (var (version, codename) in source.Codenames)
+        {
+            string url = DistroSource.ResolveFeedUrl(feed.Url, version, codename, major, minor);
+            string distroKey = $"{source.Name} {version}";
+
+            log.Write($"  [{feedName}] {distroKey}... ");
+            try
+            {
+                using var response = await http.GetAsync(url);
+                if (!response.IsSuccessStatusCode) { log.WriteLine("not found"); continue; }
+
+                using var stream = await response.Content.ReadAsStreamAsync();
+                using var json = await JsonDocument.ParseAsync(stream);
+                int totalSize = json.RootElement.GetProperty("total_size").GetInt32();
+
+                if (totalSize > 0)
+                {
+                    log.WriteLine($"FOUND ({totalSize} entries)");
+                    string pattern = source.DotnetPackagePattern ?? "dotnet-{component}-{major}.{minor}";
+
+                    if (!results.TryGetValue(distroKey, out var feeds))
+                    {
+                        feeds = [];
+                        results[distroKey] = feeds;
+                    }
+
+                    var packages = new List<DotnetDistroPackage>();
+                    foreach (var component in Components)
+                    {
+                        string pkgName = pattern
+                            .Replace("{component}", component.Id)
+                            .Replace("{major}", major)
+                            .Replace("{minor}", minor);
+                        packages.Add(new DotnetDistroPackage(component.Id, pkgName));
+                    }
+                    feeds[feedName] = packages;
+                }
+                else
+                {
+                    log.WriteLine("empty");
+                }
+            }
+            catch (Exception ex)
+            {
+                log.WriteLine($"ERROR: {ex.Message}");
+            }
+
+            await Task.Delay(200);
+        }
+    }
+
+    static async Task CheckBrewFormulaAsync(
+        DistroSource source, string feedName, DotnetFeed feed,
+        string major, string minor, HttpClient http, TextWriter log,
+        Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> results)
+    {
+        string url = DistroSource.ResolveFeedUrl(feed.Url, null, null, major, minor);
+        string distroKey = source.Name;
+
+        log.Write($"  [{feedName}] {distroKey} dotnet@{major}... ");
+        try
+        {
+            using var response = await http.GetAsync(url);
+            if (!response.IsSuccessStatusCode) { log.WriteLine("not found"); return; }
+
+            using var stream = await response.Content.ReadAsStreamAsync();
+            using var json = await JsonDocument.ParseAsync(stream);
+            string version = json.RootElement.GetProperty("versions").GetProperty("stable").GetString() ?? "unknown";
+            log.WriteLine($"FOUND (v{version})");
+
+            if (!results.TryGetValue(distroKey, out var feeds))
+            {
+                feeds = [];
+                results[distroKey] = feeds;
+            }
+
+            // Homebrew formula provides SDK + runtime in one package
+            feeds[feedName] =
+            [
+                new DotnetDistroPackage("sdk", $"dotnet@{major}", version),
+                new DotnetDistroPackage("runtime", $"dotnet@{major}", version),
+                new DotnetDistroPackage("aspnetcore-runtime", $"dotnet@{major}", version),
+            ];
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine($"ERROR: {ex.Message}");
+        }
+    }
+
+    static async Task CheckNixpkgsAsync(
+        DistroSource source, string feedName, DotnetFeed feed,
+        string major, string minor, HttpClient http, TextWriter log,
+        Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> results)
+    {
+        // Get active NixOS versions from endoflife.date
+        var nixVersions = new List<string>();
+        try
+        {
+            using var eolResponse = await http.GetAsync("https://endoflife.date/api/nixos.json");
+            eolResponse.EnsureSuccessStatusCode();
+            using var eolStream = await eolResponse.Content.ReadAsStreamAsync();
+            using var cycles = await JsonDocument.ParseAsync(eolStream);
+
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            foreach (var cycle in cycles.RootElement.EnumerateArray())
+            {
+                var eolStr = cycle.GetProperty("eol").GetString();
+                if (eolStr is not null && DateOnly.TryParse(eolStr, out var eol) && eol > today)
+                {
+                    nixVersions.Add(cycle.GetProperty("cycle").GetString()!);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine($"  [nixpkgs] Failed to get NixOS versions: {ex.Message}");
+            return;
+        }
+
+        foreach (var version in nixVersions)
+        {
+            string url = DistroSource.ResolveFeedUrl(feed.Url, version, null, major, minor);
+            string distroKey = $"NixOS {version}";
+
+            log.Write($"  [{feedName}] {distroKey} dotnet{major}... ");
+            try
+            {
+                using var response = await http.GetAsync(url);
+                if (!response.IsSuccessStatusCode) { log.WriteLine("not found"); continue; }
+
+                log.WriteLine("FOUND");
+
+                if (!results.TryGetValue(distroKey, out var feeds))
+                {
+                    feeds = [];
+                    results[distroKey] = feeds;
+                }
+
+                feeds[feedName] =
+                [
+                    new DotnetDistroPackage("sdk", $"dotnet-sdk_{major}", null),
+                    new DotnetDistroPackage("runtime", $"dotnet-runtime_{major}", null),
+                    new DotnetDistroPackage("aspnetcore-runtime", $"dotnet-aspnetcore_{major}", null),
+                ];
+            }
+            catch (Exception ex)
+            {
+                log.WriteLine($"ERROR: {ex.Message}");
+            }
+
+            await Task.Delay(200);
+        }
+    }
+
+    /// <summary>
+    /// Merges pkgs.org and supplemental results into the output model.
+    /// </summary>
+    static IList<DistroPackageAvailability> MergeResults(
+        Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> pkgsOrg,
+        Dictionary<string, Dictionary<string, List<DotnetDistroPackage>>> supplemental,
+        DistroSourceCollection distroSources)
+    {
+        // Combine all distro keys
+        var allKeys = new HashSet<string>(pkgsOrg.Keys);
+        foreach (var key in supplemental.Keys)
+            allKeys.Add(key);
+
+        // Group by distro name (everything before the last space+version, or the whole key)
+        var byDistro = new Dictionary<string, List<(string key, string version)>>();
+        foreach (var key in allKeys.OrderBy(k => k))
+        {
+            string distroName = key;
+            string version = "";
+
+            // Try to split "Ubuntu 24.04" → ("Ubuntu", "24.04")
+            int lastSpace = key.LastIndexOf(' ');
+            if (lastSpace > 0)
+            {
+                string possibleVersion = key[(lastSpace + 1)..];
+                if (possibleVersion.Length > 0 && (char.IsDigit(possibleVersion[0]) || possibleVersion == "Edge" || possibleVersion == "Rawhide" || possibleVersion == "Rolling" || possibleVersion == "Sisyphus" || possibleVersion == "Cooker"))
+                {
+                    distroName = key[..lastSpace];
+                    version = possibleVersion;
+                }
+            }
+
+            if (!byDistro.TryGetValue(distroName, out var versions))
+            {
+                versions = [];
+                byDistro[distroName] = versions;
+            }
+            versions.Add((key, version));
+        }
+
+        var result = new List<DistroPackageAvailability>();
+        foreach (var (distroName, versions) in byDistro.OrderBy(kv => kv.Key))
+        {
+            var releases = new List<DistroReleasePackages>();
+            foreach (var (key, version) in versions)
+            {
+                var feeds = new Dictionary<string, IList<DotnetDistroPackage>>();
+
+                if (pkgsOrg.TryGetValue(key, out var pkgFeeds))
+                {
+                    foreach (var (feedName, packages) in pkgFeeds)
+                        feeds[feedName] = packages;
+                }
+
+                if (supplemental.TryGetValue(key, out var suppFeeds))
+                {
+                    foreach (var (feedName, packages) in suppFeeds)
+                        feeds[feedName] = packages;
+                }
+
+                releases.Add(new DistroReleasePackages(
+                    key,
+                    version.Length > 0 ? version : "rolling",
+                    feeds.Count > 0 ? feeds : null));
+            }
+
+            result.Add(new DistroPackageAvailability(distroName, releases));
+        }
+
+        return result;
+    }
+}

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -5,9 +5,23 @@ using Dotnet.Release.Tools;
 
 // Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]
 //        dotnet-release generate <type> --export-template
+//        dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]
 // Types: supported-os, os-packages
 
-if (args.Length < 2 || args[0] != "generate")
+if (args.Length < 2)
+{
+    PrintUsage();
+    return 1;
+}
+
+string command = args[0];
+
+if (command == "query")
+{
+    return await HandleQueryAsync(args);
+}
+
+if (command != "generate")
 {
     PrintUsage();
     return 1;
@@ -146,6 +160,7 @@ static void PrintUsage()
 {
     Console.Error.WriteLine("Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]");
     Console.Error.WriteLine("       dotnet-release generate <type> --export-template");
+    Console.Error.WriteLine("       dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Types: supported-os, os-packages");
     Console.Error.WriteLine();
@@ -155,4 +170,74 @@ static void PrintUsage()
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate os-packages --export-template > my-template.md");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0 --template my-template.md");
+    Console.Error.WriteLine("  dotnet-release query distro-packages --dotnet-version 9.0");
+    Console.Error.WriteLine("  dotnet-release query distro-packages --dotnet-version 9.0 --output distro-packages.json");
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("Environment variables:");
+    Console.Error.WriteLine("  PKGS_ORG_TOKEN  API token for pkgs.org (Gold+ subscription required)");
+}
+
+async Task<int> HandleQueryAsync(string[] args)
+{
+    if (args.Length < 2)
+    {
+        PrintUsage();
+        return 1;
+    }
+
+    string queryType = args[1];
+
+    if (queryType != "distro-packages")
+    {
+        Console.Error.WriteLine($"Unknown query type: {queryType}");
+        PrintUsage();
+        return 1;
+    }
+
+    string? dotnetVersion = null;
+    string? outputPath = null;
+
+    for (int i = 2; i < args.Length; i++)
+    {
+        if (args[i] == "--dotnet-version" && i + 1 < args.Length)
+            dotnetVersion = args[++i];
+        else if (args[i] == "--output" && i + 1 < args.Length)
+            outputPath = args[++i];
+    }
+
+    if (dotnetVersion is null)
+    {
+        Console.Error.WriteLine("Error: --dotnet-version is required");
+        PrintUsage();
+        return 1;
+    }
+
+    string? token = Environment.GetEnvironmentVariable("PKGS_ORG_TOKEN");
+    if (string.IsNullOrEmpty(token))
+    {
+        Console.Error.WriteLine("Error: PKGS_ORG_TOKEN environment variable is required.");
+        Console.Error.WriteLine("Get a Gold+ subscription at https://pkgs.org/premium/");
+        return 1;
+    }
+
+    using var http = new HttpClient();
+    using var pkgsOrg = new PkgsOrgClient(token);
+
+    var overview = await DistroPackagesGenerator.QueryAsync(dotnetVersion, pkgsOrg, http, Console.Error);
+
+    // Serialize output
+    string json = JsonSerializer.Serialize(overview, DistroPackagesSerializerContext.Default.DistroPackagesOverview);
+
+    if (outputPath is not null)
+    {
+        await File.WriteAllTextAsync(outputPath, json);
+        var info = new FileInfo(outputPath);
+        Console.Error.WriteLine($"\nWrote {info.Length} bytes to {info.FullName}");
+    }
+    else
+    {
+        Console.Out.WriteLine(json);
+    }
+
+    return 0;
 }


### PR DESCRIPTION
## Summary

Adds a new CLI command to query .NET package availability across Linux distributions and package managers.

### New command

```
dotnet-release query distro-packages --dotnet-version 9.0 [--output distro-packages.json]
```

### Data sources

| Source | Role | Format |
|---|---|---|
| **pkgs.org API** | Primary — covers all distro-native packages in one search | JSON (Gold+ subscription) |
| **Launchpad API** | Ubuntu backports PPA (not in pkgs.org) | JSON |
| **formulae.brew.sh** | Homebrew formula availability | JSON |
| **GitHub API** | NixOS nixpkgs directory check | JSON |
| **endoflife.date** | Active distro versions and EOL dates | JSON |

All sources are raw data APIs — no HTML parsing.

### Distros covered (16)

Ubuntu, Alpine, Fedora, RHEL, CentOS Stream, AlmaLinux, Rocky Linux, Oracle Linux, Amazon Linux, OpenMandriva, ALT Linux, Arch Linux, Wolfi, FreeBSD, Homebrew, NixOS

### New files

**Models (Dotnet.Release.Support)**
- `distro-sources.json` — embedded metadata for 16 distros (patterns, feeds, endoflife IDs)
- `DistroSources.cs` — model + loader + URL resolver
- `DistroPackages.cs` — output model for distro-packages.json
- `PkgsOrg.cs` + `PkgsOrgClient.cs` — typed client for pkgs.org API

**Tool (Dotnet.Release.Tools)**
- `DistroPackagesGenerator.cs` — orchestrator: pkgs.org search → supplemental feeds → merge → output

**Skills**
- `update-os-packages` — audit dependency package names
- `update-supported-os` — audit distro lifecycle
- `update-distro-packages` — generate .NET package availability

### Status

- [x] Build clean, AOT compatible
- [x] Supplemental feeds verified (Homebrew, Launchpad, NixOS)
- [ ] Waiting for pkgs.org Gold API key for end-to-end test

### Environment

Requires `PKGS_ORG_TOKEN` environment variable (pkgs.org Gold+ subscription).