### PR TITLE
Update Markout to 0.10.0 and related packages

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Release.Support\Dotnet.Release.Support.csproj" />
     <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
-    <PackageReference Include="Markout" Version="0.6.1" />
-    <PackageReference Include="Markout.Templates" Version="0.1.0" />
-    <PackageReference Include="MarkdownTable.Formatting" Version="0.1.0" />
+    <PackageReference Include="Markout" Version="0.10.0" />
+    <PackageReference Include="Markout.Templates" Version="0.2.0" />
+    <PackageReference Include="MarkdownTable.Formatting" Version="0.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotnet.Release.Tools/OsPackagesGenerator.cs
+++ b/src/Dotnet.Release.Tools/OsPackagesGenerator.cs
@@ -89,7 +89,7 @@ public static class OsPackagesGenerator
                 items.Add(linkRef);
             }
 
-            writer.WriteList(items);
+            writer.WriteList(items.ToArray());
 
             // Note about globalization invariant mode
             writer.WriteParagraph("You do not need to install ICU if you [enable globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode).");

--- a/src/Dotnet.Release.Tools/SupportedOsGenerator.cs
+++ b/src/Dotnet.Release.Tools/SupportedOsGenerator.cs
@@ -177,7 +177,7 @@ public static class SupportedOsGenerator
                 if (notes.Count > 0)
                 {
                     writer.WriteParagraph("Notes:");
-                    writer.WriteList(notes);
+                    writer.WriteList(notes.ToArray());
                 }
             }
         }
@@ -206,7 +206,7 @@ public static class SupportedOsGenerator
     {
         public void WriteTo(MarkoutWriter writer)
         {
-            writer.WriteList(notes);
+            writer.WriteList(notes.ToArray());
         }
     }
 


### PR DESCRIPTION
Updates NuGet package dependencies:

| Package | Old | New |
|---|---|---|
| Markout | 0.6.1 | 0.10.0 |
| Markout.Templates | 0.1.0 | 0.2.0 |
| MarkdownTable.Formatting | 0.1.0 | 0.3.1 |

### Code changes

`MarkoutWriter.WriteList` signature changed from `IList<string>` to `ReadOnlySpan<string>`. Updated 3 call sites in `OsPackagesGenerator.cs` and `SupportedOsGenerator.cs` to use `.ToArray()` for the implicit span conversion.

### Validation

- Build succeeds with zero warnings
- All 24 tests pass