### PR TITLE
Fix Markout version reference: 10.0.2 → 0.10.2

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Release.Support\Dotnet.Release.Support.csproj" />
     <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
-    <PackageReference Include="Markout" Version="10.0.2" />
+    <PackageReference Include="Markout" Version="0.10.2" />
     <PackageReference Include="Markout.Templates" Version="0.2.0" />
     <PackageReference Include="MarkdownTable.Formatting" Version="0.3.3" />
   </ItemGroup>


### PR DESCRIPTION
Matches the corrected Markout version (0.10.2) from richlander/markout#94.