### PR TITLE
Add generate distro-packages command for per-distro JSON files

### DIFF
--- a/src/Dotnet.Release.Support/DistroPackageFile.cs
+++ b/src/Dotnet.Release.Support/DistroPackageFile.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Support;
+
+// Per-distro package file for distro-packages/<distro>.json
+// Combines dependencies (.NET needs) with dotnet packages (where to get .NET)
+[Description("Per-distro package information for a given .NET version.")]
+public record DistroPackageFile(
+    [property: Description("Distribution name.")]
+    string Name,
+
+    [property: Description("Command to install dependency packages (e.g. 'apt-get install -y {packages}').")]
+    string InstallCommand,
+
+    [property: Description("Releases of this distribution.")]
+    IList<DistroPackageRelease> Releases);
+
+[Description("A distribution release with dependencies and .NET package availability.")]
+public record DistroPackageRelease(
+    [property: Description("Display name for the release.")]
+    string Name,
+
+    [property: Description("Version string for the release.")]
+    string Release,
+
+    [property: Description("Packages required to run .NET on this release.")]
+    IList<DistroDepPackage> Dependencies,
+
+    [property: Description("Built-in .NET packages available in the distro archive.")]
+    IList<DotnetComponentPackage>? DotnetPackages = null,
+
+    [property: Description("Alternative feed .NET packages (keyed by feed name).")]
+    IDictionary<string, DotnetAlternativeFeed>? DotnetPackagesOther = null,
+
+    [property: Description("Notes about this release (e.g. SDK band limitations).")]
+    IList<string>? Notes = null);
+
+[Description("A dependency package required by .NET.")]
+public record DistroDepPackage(
+    [property: Description("Reference to nominal package ID (e.g. 'libicu').")]
+    string Id,
+
+    [property: Description("Package name in the distro archive (e.g. 'libicu78').")]
+    string Name);
+
+[Description("A .NET component package available in a feed.")]
+public record DotnetComponentPackage(
+    [property: Description("Component identifier (e.g. 'sdk', 'runtime', 'aspnetcore_runtime').")]
+    string Component,
+
+    [property: Description("Package name in the archive.")]
+    string Name);
+
+[Description("An alternative package feed with setup instructions.")]
+public record DotnetAlternativeFeed(
+    [property: Description("Command to register this feed.")]
+    string InstallCommand,
+
+    [property: Description(".NET packages available from this feed.")]
+    IList<DotnetComponentPackage> Packages);

--- a/src/Dotnet.Release.Support/SupportSerializerContexts.cs
+++ b/src/Dotnet.Release.Support/SupportSerializerContexts.cs
@@ -25,3 +25,12 @@ public partial class SupportedOSMatrixSerializerContext : JsonSerializerContext
 public partial class DistroPackagesSerializerContext : JsonSerializerContext
 {
 }
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(DistroPackageFile))]
+public partial class DistroPackageFileSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.Tools/DistroPackageFileGenerator.cs
+++ b/src/Dotnet.Release.Tools/DistroPackageFileGenerator.cs
@@ -1,0 +1,160 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Dotnet.Release.Support;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates per-distro package files by merging os-packages.json (dependencies)
+/// with distro-packages query results (dotnet package availability).
+/// </summary>
+public static class DistroPackageFileGenerator
+{
+    /// <summary>
+    /// Build install command string from os-packages.json Command records.
+    /// </summary>
+    static string BuildInstallCommand(IList<Command> commands)
+    {
+        // Take the last command (the install one, not the update preamble)
+        var cmd = commands.Last();
+        var parts = new List<string> { cmd.CommandRoot };
+        if (cmd.CommandParts is not null)
+        {
+            parts.AddRange(cmd.CommandParts);
+        }
+
+        string result = string.Join(" ", parts);
+        // Normalize placeholder
+        return result.Replace("{packageName}", "{packages}");
+    }
+
+    /// <summary>
+    /// Generate per-distro JSON files from os-packages.json data,
+    /// optionally enriched with distro-packages query results.
+    /// </summary>
+    public static IList<(string fileName, DistroPackageFile file)> Generate(
+        OSPackagesOverview osPackages,
+        DistroPackagesOverview? distroPackages = null)
+    {
+        var results = new List<(string, DistroPackageFile)>();
+
+        foreach (var dist in osPackages.Distributions)
+        {
+            string fileName = dist.Name.ToLowerInvariant()
+                .Replace(" ", "_");
+
+            // Build install command
+            string installCommand = BuildInstallCommand(dist.InstallCommands);
+
+            // Build releases
+            var releases = new List<DistroPackageRelease>();
+
+            foreach (var rel in dist.Releases)
+            {
+                // Dependencies from os-packages.json
+                var deps = rel.Packages.Select(p =>
+                    new DistroDepPackage(p.Id, p.Name)).ToList();
+
+                // Look up dotnet packages from query results
+                IList<DotnetComponentPackage>? builtinPackages = null;
+                Dictionary<string, DotnetAlternativeFeed>? otherFeeds = null;
+
+                if (distroPackages is not null)
+                {
+                    var matchingDistro = FindMatchingDistro(distroPackages, dist.Name, rel.Release);
+
+                    if (matchingDistro is not null)
+                    {
+                        foreach (var (feedName, packages) in matchingDistro)
+                        {
+                            var components = packages.Select(p =>
+                                new DotnetComponentPackage(p.ComponentId, p.PackageName)).ToList();
+
+                            if (feedName == "builtin")
+                            {
+                                builtinPackages = components;
+                            }
+                            else
+                            {
+                                otherFeeds ??= new Dictionary<string, DotnetAlternativeFeed>();
+                                // Feed install commands would need to come from distro-sources.json
+                                // For now, use a placeholder
+                                otherFeeds[feedName] = new DotnetAlternativeFeed(
+                                    InstallCommand: $"# See distro documentation for {feedName} feed setup",
+                                    Packages: components);
+                            }
+                        }
+                    }
+                }
+
+                releases.Add(new DistroPackageRelease(
+                    Name: rel.Name,
+                    Release: rel.Release,
+                    Dependencies: deps,
+                    DotnetPackages: builtinPackages,
+                    DotnetPackagesOther: otherFeeds));
+            }
+
+            results.Add((fileName, new DistroPackageFile(
+                Name: dist.Name,
+                InstallCommand: installCommand,
+                Releases: releases)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Find matching distro release in query results. Handles case-insensitive
+    /// and partial name matching (e.g. "Ubuntu" matches "ubuntu" or "Ubuntu").
+    /// </summary>
+    static IDictionary<string, IList<DotnetDistroPackage>>? FindMatchingDistro(
+        DistroPackagesOverview distroPackages, string distroName, string release)
+    {
+        foreach (var dist in distroPackages.Distributions)
+        {
+            // Match by name (case-insensitive)
+            if (!dist.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase) &&
+                !dist.Name.StartsWith(distroName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var rel in dist.Releases)
+            {
+                if (rel.Release == release && rel.Feeds is not null)
+                {
+                    return rel.Feeds;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Write per-distro JSON files to a directory.
+    /// </summary>
+    public static void WriteToDirectory(
+        IList<(string fileName, DistroPackageFile file)> files,
+        string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+        var writerOptions = new JsonWriterOptions
+        {
+            Indented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        foreach (var (fileName, file) in files)
+        {
+            string path = Path.Combine(outputDir, $"{fileName}.json");
+            using var stream = File.Create(path);
+            using var writer = new Utf8JsonWriter(stream, writerOptions);
+            JsonSerializer.Serialize(writer, file,
+                DistroPackageFileSerializerContext.Default.DistroPackageFile);
+            // Add trailing newline
+            stream.WriteByte((byte)'\n');
+        }
+    }
+}

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -5,8 +5,9 @@ using Dotnet.Release.Tools;
 
 // Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]
 //        dotnet-release generate <type> --export-template
+//        dotnet-release verify <type> <version> [path-or-url]
 //        dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]
-// Types: supported-os, os-packages
+// Types: supported-os, os-packages, distro-packages
 
 if (args.Length < 2)
 {
@@ -85,6 +86,8 @@ switch (type)
         return await GenerateSupportedOsAsync(path, version, client, templatePath);
     case "os-packages":
         return await GenerateOsPackagesAsync(path, version, client, templatePath);
+    case "distro-packages":
+        return await GenerateDistroPackageFilesAsync(path, version, client);
     default:
         Console.Error.WriteLine($"Unknown type: {type}");
         PrintUsage();
@@ -156,6 +159,62 @@ async Task<int> GenerateOsPackagesAsync(IAdaptivePath path, string version, Http
         var info = new FileInfo(outputPath);
         Console.Error.WriteLine($"Generated {info.Length} bytes");
         Console.Error.WriteLine(info.FullName);
+    }
+
+    return 0;
+}
+
+async Task<int> GenerateDistroPackageFilesAsync(IAdaptivePath path, string version, HttpClient client)
+{
+    // Read os-packages.json (required — provides dependencies)
+    string osJsonPath = path.Combine(version, "os-packages.json");
+    Console.Error.WriteLine($"Reading {osJsonPath}...");
+
+    using var osStream = await path.GetStreamAsync(osJsonPath);
+    var osPackages = await JsonSerializer.DeserializeAsync(osStream, OSPackagesSerializerContext.Default.OSPackagesOverview)
+        ?? throw new InvalidOperationException("Failed to deserialize os-packages.json");
+
+    // Try to read distro-packages query results (optional — enriches with dotnet package info)
+    DistroPackagesOverview? distroPackages = null;
+    string distroJsonPath = path.Combine(version, "distro-packages.json");
+
+    try
+    {
+        using var distroStream = await path.GetStreamAsync(distroJsonPath);
+        distroPackages = await JsonSerializer.DeserializeAsync(distroStream, DistroPackagesSerializerContext.Default.DistroPackagesOverview);
+        Console.Error.WriteLine($"Read {distroJsonPath} (enriching with dotnet package data)");
+    }
+    catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or HttpRequestException)
+    {
+        Console.Error.WriteLine("No distro-packages.json found (generating dependencies only)");
+    }
+
+    // Generate per-distro files
+    var files = DistroPackageFileGenerator.Generate(osPackages, distroPackages);
+
+    if (path.SupportsLocalPaths)
+    {
+        string outputDir = path.Combine(version, "distro-packages");
+        DistroPackageFileGenerator.WriteToDirectory(files, outputDir);
+
+        Console.Error.WriteLine($"Generated {files.Count} files in {Path.GetFullPath(outputDir)}/");
+        foreach (var (fileName, _) in files)
+        {
+            Console.Error.WriteLine($"  {fileName}.json");
+        }
+    }
+    else
+    {
+        // When reading from URL, write all files to stdout as a JSON array
+        Console.Out.Write('[');
+        for (int i = 0; i < files.Count; i++)
+        {
+            if (i > 0) Console.Out.Write(',');
+            var json = JsonSerializer.Serialize(files[i].file,
+                DistroPackageFileSerializerContext.Default.DistroPackageFile);
+            Console.Out.Write(json);
+        }
+        Console.Out.WriteLine(']');
     }
 
     return 0;


### PR DESCRIPTION
Adds a `generate distro-packages` command that produces per-distro JSON files by merging `os-packages.json` (dependency data) with optional `distro-packages.json` query results (dotnet package availability).

## Changes

- **`DistroPackageFile.cs`** — New record types for the per-distro JSON schema (`DistroPackageFile`, `DistroPackageRelease`, `DistroDepPackage`, `DotnetComponentPackage`, `DotnetAlternativeFeed`)
- **`SupportSerializerContexts.cs`** — Added `DistroPackageFileSerializerContext` (snake_case, null-omitting)
- **`DistroPackageFileGenerator.cs`** — Generator that merges os-packages dependencies with distro-packages feeds, writes per-distro JSON files to a directory
- **`Program.cs`** — CLI integration: `dotnet-release generate distro-packages <version> [path]`

## Behavior

- Reads `os-packages.json` (required) for dependency information
- Optionally reads `distro-packages.json` to enrich output with builtin/alternative feed package data
- Writes one `<distro>.json` file per distribution to a `distro-packages/` subdirectory
- Falls back to stdout JSON array when reading from a URL