### PR TITLE
Add generate dotnet-dependencies command

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <EmbeddedResource Include="supported-os-template.md" />
     <EmbeddedResource Include="os-packages-template.md" />
+    <EmbeddedResource Include="dotnet-dependencies-template.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Release.Tools/DotnetDependenciesGenerator.cs
+++ b/src/Dotnet.Release.Tools/DotnetDependenciesGenerator.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using Dotnet.Release.Support;
+using Markout;
+using Markout.Templates;
+using MarkdownTable.Formatting;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates dotnet-dependencies.md from distros/ JSON files using a Markout template.
+/// </summary>
+public static class DotnetDependenciesGenerator
+{
+    private const string EmbeddedTemplateName = "Dotnet.Release.Tools.dotnet-dependencies-template.md";
+
+    public static MarkoutTemplate LoadTemplate(string? templatePath = null)
+    {
+        if (templatePath is not null)
+            return MarkoutTemplate.Load(templatePath);
+
+        var stream = typeof(DotnetDependenciesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+
+        return MarkoutTemplate.Load(stream);
+    }
+
+    public static void ExportTemplate(TextWriter output)
+    {
+        using var stream = typeof(DotnetDependenciesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+        using var reader = new StreamReader(stream);
+        output.Write(reader.ReadToEnd());
+    }
+
+    public static void Generate(
+        DependenciesFile dependencies,
+        DistrosIndex index,
+        IList<DistroPackageFile> distros,
+        TextWriter output,
+        string version,
+        string? templatePath = null)
+    {
+        var template = LoadTemplate(templatePath);
+        template.TableOptions = new TableFormatterOptions();
+
+        template.Bind("version", version);
+        template.Bind("overview", new OverviewBinding(dependencies.Packages));
+        template.Bind("distros", new DistrosBinding(distros));
+
+        var options = new MarkoutWriterOptions { PrettyTables = true };
+        template.SkipUnboundPlaceholders = true;
+        output.WriteLine(template.Render(options));
+    }
+
+    /// <summary>
+    /// Renders the package overview as a list with links.
+    /// </summary>
+    private class OverviewBinding(IList<DependencyPackage> packages) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            var items = new List<string>();
+            var linkDefs = new List<string>();
+            int linkIndex = 0;
+
+            foreach (var package in packages)
+            {
+                string linkRef = $"[{package.Name}][{linkIndex}]";
+
+                string url = package.References is { Count: > 0 }
+                    ? package.References[0]
+                    : $"https://pkgs.org/search/?q={package.Id}";
+
+                linkDefs.Add($"[{linkIndex}]: {url}");
+                linkIndex++;
+
+                items.Add(linkRef);
+            }
+
+            writer.WriteList(items.ToArray());
+
+            writer.WriteParagraph("You do not need to install ICU if you [enable globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode).");
+            writer.WriteParagraph("If your app relies on `https` endpoints, you'll also need to install `ca-certificates`.");
+
+            writer.WriteLinkDefinitions(linkDefs.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Renders per-distro install commands with bash code blocks.
+    /// </summary>
+    private class DistrosBinding(IList<DistroPackageFile> distros) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            foreach (var distro in distros)
+            {
+                writer.WriteHeading(2, distro.Name);
+
+                foreach (var release in distro.Releases)
+                {
+                    writer.WriteHeading(3, release.Name);
+
+                    writer.WriteCodeStart("bash");
+                    string codeBlock = BuildInstallCommand(distro.InstallCommand, release.Dependencies);
+                    writer.WriteParagraph(codeBlock);
+                    writer.WriteCodeEnd();
+                }
+            }
+        }
+
+        private static string BuildInstallCommand(string installCommand, IList<DistroDepPackage> dependencies)
+        {
+            var sb = new StringBuilder();
+
+            // Parse the install command — add sudo prefix and handle multi-part commands
+            // e.g. "apt-get install -y {packages}" or "apk add {packages}"
+            string command = installCommand.Replace("{packages}", "").TrimEnd();
+
+            // Check for update preamble patterns (apt-get needs update first)
+            if (command.StartsWith("apt-get"))
+            {
+                sb.AppendLine("sudo apt-get update && \\");
+                sb.Append("sudo ");
+            }
+            else
+            {
+                sb.Append("sudo ");
+            }
+
+            sb.Append(command);
+            sb.AppendLine(" \\");
+
+            var sorted = dependencies.OrderBy(p => p.Name).ToList();
+            string indent = new(' ', 4);
+
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                sb.Append(indent);
+                sb.Append(sorted[i].Name);
+
+                if (i + 1 < sorted.Count)
+                    sb.AppendLine(" \\");
+                else
+                    sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+    }
+}

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -46,6 +46,9 @@ if (args.Length > 2 && args[2] == "--export-template")
         case "os-packages":
             OsPackagesGenerator.ExportTemplate(Console.Out);
             break;
+        case "dotnet-dependencies":
+            DotnetDependenciesGenerator.ExportTemplate(Console.Out);
+            break;
         default:
             Console.Error.WriteLine($"Unknown type: {type}");
             PrintUsage();
@@ -86,6 +89,8 @@ switch (type)
         return await GenerateSupportedOsAsync(path, version, client, templatePath);
     case "os-packages":
         return await GenerateOsPackagesAsync(path, version, client, templatePath);
+    case "dotnet-dependencies":
+        return await GenerateDotnetDependenciesAsync(path, version, client, templatePath);
     default:
         Console.Error.WriteLine($"Unknown type: {type}");
         PrintUsage();
@@ -162,6 +167,64 @@ async Task<int> GenerateOsPackagesAsync(IAdaptivePath path, string version, Http
     return 0;
 }
 
+async Task<int> GenerateDotnetDependenciesAsync(IAdaptivePath path, string version, HttpClient client, string? templatePath)
+{
+    // Read distros/index.json
+    string indexPath = path.Combine(version, FileNames.Directories.Distros, FileNames.Index);
+    Console.Error.WriteLine($"Reading {indexPath}...");
+
+    using var indexStream = await path.GetStreamAsync(indexPath);
+    var index = await JsonSerializer.DeserializeAsync(indexStream, DistrosIndexSerializerContext.Default.DistrosIndex)
+        ?? throw new InvalidOperationException("Failed to deserialize index.json");
+
+    // Read distros/dependencies.json
+    string depsPath = path.Combine(version, FileNames.Directories.Distros, FileNames.Dependencies);
+    Console.Error.WriteLine($"Reading {depsPath}...");
+
+    using var depsStream = await path.GetStreamAsync(depsPath);
+    var dependencies = await JsonSerializer.DeserializeAsync(depsStream, DependenciesFileSerializerContext.Default.DependenciesFile)
+        ?? throw new InvalidOperationException("Failed to deserialize dependencies.json");
+
+    // Read each per-distro file
+    var distros = new List<DistroPackageFile>();
+    foreach (var distroFile in index.Distros)
+    {
+        string distroPath = path.Combine(version, FileNames.Directories.Distros, distroFile);
+        Console.Error.WriteLine($"Reading {distroPath}...");
+
+        using var distroStream = await path.GetStreamAsync(distroPath);
+        var distro = await JsonSerializer.DeserializeAsync(distroStream, DistroPackageFileSerializerContext.Default.DistroPackageFile)
+            ?? throw new InvalidOperationException($"Failed to deserialize {distroFile}");
+
+        distros.Add(distro);
+    }
+
+    TextWriter output;
+    string? outputPath = null;
+
+    if (path.SupportsLocalPaths)
+    {
+        outputPath = path.Combine(version, "dotnet-dependencies.md");
+        output = new StreamWriter(File.Open(outputPath, FileMode.Create));
+    }
+    else
+    {
+        output = Console.Out;
+    }
+
+    DotnetDependenciesGenerator.Generate(dependencies, index, distros, output, version, templatePath: templatePath);
+
+    if (outputPath is not null)
+    {
+        await output.DisposeAsync();
+        var info = new FileInfo(outputPath);
+        Console.Error.WriteLine($"Generated {info.Length} bytes");
+        Console.Error.WriteLine(info.FullName);
+    }
+
+    return 0;
+}
+
 static void PrintUsage()
 {
     Console.Error.WriteLine("Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]");
@@ -169,11 +232,13 @@ static void PrintUsage()
     Console.Error.WriteLine("       dotnet-release verify <type> <version> [path-or-url]");
     Console.Error.WriteLine("       dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]");
     Console.Error.WriteLine();
-    Console.Error.WriteLine("Types: supported-os, os-packages");
+    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0");
     Console.Error.WriteLine("  dotnet-release generate os-packages 10.0");
+    Console.Error.WriteLine("  dotnet-release generate dotnet-dependencies 11.0");
+    Console.Error.WriteLine("  dotnet-release generate dotnet-dependencies 11.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate os-packages --export-template > my-template.md");
     Console.Error.WriteLine("  dotnet-release verify supported-os 10.0");

--- a/src/Dotnet.Release.Tools/dotnet-dependencies-template.md
+++ b/src/Dotnet.Release.Tools/dotnet-dependencies-template.md
@@ -1,0 +1,14 @@
+# .NET {{version}} Linux package dependencies
+
+.NET {{version}} has several dependencies that must be installed to run .NET apps. The install commands for each supported Linux distribution are listed below.
+
+Tips:
+
+- [runtime-deps container images](https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps) install these same packages.
+- [pkgs.org](https://pkgs.org/) is useful for searching packages across distributions.
+
+## Packages
+
+{{overview}}
+
+{{distros}}


### PR DESCRIPTION
## Summary

Adds a new `generate dotnet-dependencies` command that reads the per-distro JSON files in `distros/` and generates `dotnet-dependencies.md` — a user-facing markdown file with copy-pasteable install commands for each Linux distribution.

## Usage

```bash
dotnet-release generate dotnet-dependencies 11.0 ~/git/core/release-notes
```

## How it works

Reads three file types from `release-notes/{version}/distros/`:
- `index.json` — which distro files to process
- `dependencies.json` — package overview (names, scenarios, links)
- `{distro}.json` — per-distro dependency mappings

Generates `dotnet-dependencies.md` with:
- Package overview section with links
- Per-distro sections with bash install snippets per release

Uses the same Markout template system as `generate os-packages` and `generate supported-os`.

## Files

- `DotnetDependenciesGenerator.cs` — generator with template bindings
- `dotnet-dependencies-template.md` — embedded Markout template
- `Program.cs` — command wiring
- `Dotnet.Release.Tools.csproj` — embedded resource registration