### PR TITLE
Add generate dotnet-packages command

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->
@@ -35,6 +35,7 @@
     <EmbeddedResource Include="supported-os-template.md" />
     <EmbeddedResource Include="os-packages-template.md" />
     <EmbeddedResource Include="dotnet-dependencies-template.md" />
+    <EmbeddedResource Include="dotnet-packages-template.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Release.Tools/DotnetPackagesGenerator.cs
+++ b/src/Dotnet.Release.Tools/DotnetPackagesGenerator.cs
@@ -1,0 +1,202 @@
+using System.Text;
+using Dotnet.Release.Support;
+using Markout;
+using Markout.Templates;
+using MarkdownTable.Formatting;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates dotnet-packages.md from distros/ JSON files using a Markout template.
+/// Shows which .NET packages are available in each distro's package feeds.
+/// </summary>
+public static class DotnetPackagesGenerator
+{
+    private const string EmbeddedTemplateName = "Dotnet.Release.Tools.dotnet-packages-template.md";
+
+    public static MarkoutTemplate LoadTemplate(string? templatePath = null)
+    {
+        if (templatePath is not null)
+            return MarkoutTemplate.Load(templatePath);
+
+        var stream = typeof(DotnetPackagesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+
+        return MarkoutTemplate.Load(stream);
+    }
+
+    public static void ExportTemplate(TextWriter output)
+    {
+        using var stream = typeof(DotnetPackagesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+        using var reader = new StreamReader(stream);
+        output.Write(reader.ReadToEnd());
+    }
+
+    public static void Generate(
+        DistrosIndex index,
+        IList<DistroPackageFile> distros,
+        TextWriter output,
+        string version,
+        string? templatePath = null)
+    {
+        var template = LoadTemplate(templatePath);
+        template.TableOptions = new TableFormatterOptions();
+
+        template.Bind("version", version);
+        template.Bind("summary", new SummaryBinding(distros));
+        template.Bind("distros", new DistrosBinding(distros));
+
+        var options = new MarkoutWriterOptions { PrettyTables = true };
+        template.SkipUnboundPlaceholders = true;
+        output.WriteLine(template.Render(options));
+    }
+
+    /// <summary>
+    /// Renders a summary table showing package availability across distros.
+    /// </summary>
+    private class SummaryBinding(IList<DistroPackageFile> distros) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteTableStart("Distribution", "Version", "Feed");
+
+            foreach (var distro in distros)
+            {
+                foreach (var release in distro.Releases)
+                {
+                    bool hasBuiltin = release.DotnetPackages is { Count: > 0 };
+                    bool hasOther = release.DotnetPackagesOther is { Count: > 0 };
+
+                    if (!hasBuiltin && !hasOther)
+                        continue;
+
+                    var feeds = new List<string>();
+                    if (hasBuiltin)
+                        feeds.Add("Built-in");
+                    if (hasOther)
+                        feeds.AddRange(release.DotnetPackagesOther!.Keys.Select(FormatFeedName));
+
+                    writer.WriteTableRow(distro.Name, release.Name, string.Join(", ", feeds));
+                }
+            }
+
+            writer.WriteTableEnd();
+        }
+    }
+
+    /// <summary>
+    /// Renders per-distro install commands for .NET packages.
+    /// </summary>
+    private class DistrosBinding(IList<DistroPackageFile> distros) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            foreach (var distro in distros)
+            {
+                // Skip distros with no packages on any release
+                bool hasAnyPackages = distro.Releases.Any(r =>
+                    r.DotnetPackages is { Count: > 0 } ||
+                    r.DotnetPackagesOther is { Count: > 0 });
+
+                if (!hasAnyPackages)
+                    continue;
+
+                writer.WriteHeading(2, distro.Name);
+
+                foreach (var release in distro.Releases)
+                {
+                    bool hasBuiltin = release.DotnetPackages is { Count: > 0 };
+                    bool hasOther = release.DotnetPackagesOther is { Count: > 0 };
+
+                    if (!hasBuiltin && !hasOther)
+                        continue;
+
+                    writer.WriteHeading(3, release.Name);
+
+                    if (hasBuiltin)
+                    {
+                        WriteInstallBlock(writer, distro.InstallCommand, release.DotnetPackages!);
+                    }
+
+                    if (hasOther)
+                    {
+                        foreach (var (feedName, feed) in release.DotnetPackagesOther!)
+                        {
+                            writer.WriteParagraph($"**{FormatFeedName(feedName)}:**");
+
+                            if (!string.IsNullOrEmpty(feed.InstallCommand))
+                            {
+                                writer.WriteParagraph("Register the feed:");
+
+                                writer.WriteCodeStart("bash");
+                                writer.WriteParagraph(feed.InstallCommand);
+                                writer.WriteCodeEnd();
+                            }
+
+                            WriteInstallBlock(writer, distro.InstallCommand, feed.Packages);
+                        }
+                    }
+
+                    if (release.Notes is { Count: > 0 })
+                    {
+                        writer.WriteParagraph(string.Join(" ", release.Notes.Select(n => $"> {n}")));
+                    }
+                }
+            }
+        }
+
+        private static void WriteInstallBlock(MarkoutWriter writer, string installCommand, IList<DotnetComponentPackage> packages)
+        {
+            writer.WriteCodeStart("bash");
+            string codeBlock = BuildInstallCommand(installCommand, packages);
+            writer.WriteParagraph(codeBlock);
+            writer.WriteCodeEnd();
+        }
+
+        private static string BuildInstallCommand(string installCommand, IList<DotnetComponentPackage> packages)
+        {
+            var sb = new StringBuilder();
+
+            string command = installCommand.Replace("{packages}", "").TrimEnd();
+
+            if (command.StartsWith("apt-get"))
+            {
+                sb.AppendLine("sudo apt-get update && \\");
+                sb.Append("sudo ");
+            }
+            else
+            {
+                sb.Append("sudo ");
+            }
+
+            sb.Append(command);
+            sb.AppendLine(" \\");
+
+            var sorted = packages.OrderBy(p => p.Name).ToList();
+            string indent = new(' ', 4);
+
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                sb.Append(indent);
+                sb.Append(sorted[i].Name);
+
+                if (i + 1 < sorted.Count)
+                    sb.AppendLine(" \\");
+                else
+                    sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+    }
+
+    private static string FormatFeedName(string feedName) => feedName switch
+    {
+        "backports" => "Backports PPA",
+        "microsoft" => "Microsoft PMC",
+        "core" => "Homebrew Core",
+        "nixpkgs" => "Nixpkgs",
+        _ => char.ToUpper(feedName[0]) + feedName[1..]
+    };
+}

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -49,6 +49,9 @@ if (args.Length > 2 && args[2] == "--export-template")
         case "dotnet-dependencies":
             DotnetDependenciesGenerator.ExportTemplate(Console.Out);
             break;
+        case "dotnet-packages":
+            DotnetPackagesGenerator.ExportTemplate(Console.Out);
+            break;
         default:
             Console.Error.WriteLine($"Unknown type: {type}");
             PrintUsage();
@@ -91,6 +94,8 @@ switch (type)
         return await GenerateOsPackagesAsync(path, version, client, templatePath);
     case "dotnet-dependencies":
         return await GenerateDotnetDependenciesAsync(path, version, client, templatePath);
+    case "dotnet-packages":
+        return await GenerateDotnetPackagesAsync(path, version, client, templatePath);
     default:
         Console.Error.WriteLine($"Unknown type: {type}");
         PrintUsage();
@@ -213,6 +218,56 @@ async Task<int> GenerateDotnetDependenciesAsync(IAdaptivePath path, string versi
     }
 
     DotnetDependenciesGenerator.Generate(dependencies, index, distros, output, version, templatePath: templatePath);
+
+    if (outputPath is not null)
+    {
+        await output.DisposeAsync();
+        var info = new FileInfo(outputPath);
+        Console.Error.WriteLine($"Generated {info.Length} bytes");
+        Console.Error.WriteLine(info.FullName);
+    }
+
+    return 0;
+}
+
+async Task<int> GenerateDotnetPackagesAsync(IAdaptivePath path, string version, HttpClient client, string? templatePath)
+{
+    // Read distros/index.json
+    string indexPath = path.Combine(version, FileNames.Directories.Distros, FileNames.Index);
+    Console.Error.WriteLine($"Reading {indexPath}...");
+
+    using var indexStream = await path.GetStreamAsync(indexPath);
+    var index = await JsonSerializer.DeserializeAsync(indexStream, DistrosIndexSerializerContext.Default.DistrosIndex)
+        ?? throw new InvalidOperationException("Failed to deserialize index.json");
+
+    // Read each per-distro file
+    var distros = new List<DistroPackageFile>();
+    foreach (var distroFile in index.Distros.Keys)
+    {
+        string distroPath = path.Combine(version, FileNames.Directories.Distros, distroFile);
+        Console.Error.WriteLine($"Reading {distroPath}...");
+
+        using var distroStream = await path.GetStreamAsync(distroPath);
+        var distro = await JsonSerializer.DeserializeAsync(distroStream, DistroPackageFileSerializerContext.Default.DistroPackageFile)
+            ?? throw new InvalidOperationException($"Failed to deserialize {distroFile}");
+
+        distros.Add(distro);
+    }
+
+    TextWriter output;
+    string? outputPath = null;
+
+    if (path.SupportsLocalPaths)
+    {
+        outputPath = path.Combine(version, "dotnet-packages.md");
+        output = new StreamWriter(File.Open(outputPath, FileMode.Create));
+    }
+    else
+    {
+        output = Console.Out;
+    }
+
+    DotnetPackagesGenerator.Generate(index, distros, output, version, templatePath: templatePath);
 
     if (outputPath is not null)
     {

--- a/src/Dotnet.Release.Tools/dotnet-packages-template.md
+++ b/src/Dotnet.Release.Tools/dotnet-packages-template.md
@@ -1,0 +1,7 @@
+# .NET {{version}} Linux packages
+
+.NET {{version}} is available in the package feeds of the following Linux distributions.
+
+{{summary}}
+
+{{distros}}


### PR DESCRIPTION
## Changes

- **`generate dotnet-packages` command** — produces `dotnet-packages.md` from `distros/` JSON files showing where .NET packages are available across Linux distros
  - Summary table: distro, version, feed (Built-in / Backports PPA / etc.)
  - Per-distro sections with bash install snippets
  - Alternative feed handling with registration commands
- **Version bump** to 0.4.0

## Testing

- Built and ran against 10.0 distro data — produces clean 2.7KB markdown
- All 24 existing tests pass

Companion PR: dotnet/core#10322 (skill + 11.0 data)