### PR TITLE
Fix AUR feed name casing

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->

--- a/src/Dotnet.Release.Tools/DotnetPackagesGenerator.cs
+++ b/src/Dotnet.Release.Tools/DotnetPackagesGenerator.cs
@@ -197,6 +197,7 @@ public static class DotnetPackagesGenerator
         "microsoft" => "Microsoft PMC",
         "core" => "Homebrew Core",
         "nixpkgs" => "Nixpkgs",
+        "aur" => "AUR",
         _ => char.ToUpper(feedName[0]) + feedName[1..]
     };
 }


### PR DESCRIPTION
Adds explicit `"aur" => "AUR"` mapping in `FormatFeedName`. The fallback title-casing produced `Aur`.

Version bump to 0.4.1.