### PR TITLE
Add CVE enricher tool and handler library

### DIFF
--- a/DotnetRelease.slnx
+++ b/DotnetRelease.slnx
@@ -7,6 +7,8 @@
     <Project Path="src/Dotnet.Release.Support/Dotnet.Release.Support.csproj" />
     <Project Path="src/Dotnet.Release.Client/Dotnet.Release.Client.csproj" />
     <Project Path="src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj" />
+    <Project Path="src/Dotnet.Release.CveHandler/Dotnet.Release.CveHandler.csproj" />
+    <Project Path="src/Dotnet.Release.CveEnricher/Dotnet.Release.CveEnricher.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Dotnet.Release.Graph.Tests/Dotnet.Release.Graph.Tests.csproj" />

--- a/src/Dotnet.Release.CveEnricher/Dotnet.Release.CveEnricher.csproj
+++ b/src/Dotnet.Release.CveEnricher/Dotnet.Release.CveEnricher.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotnet-cve-enricher</ToolCommandName>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PackageId>Dotnet.Release.CveEnricher</PackageId>
+    <Description>CLI tool for synthesizing, validating, and enriching .NET CVE disclosure data</Description>
+    <!-- Size optimizations for Native AOT -->
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <OptimizationPreference>Size</OptimizationPreference>
+    <!-- RID-specific tool packaging: Native AOT for common platforms, CoreCLR fallback for others -->
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Release.CveHandler\Dotnet.Release.CveHandler.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Cve\Dotnet.Release.Cve.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dotnet.Release.CveEnricher/Program.cs
+++ b/src/Dotnet.Release.CveEnricher/Program.cs
@@ -1,0 +1,1228 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Dotnet.Release.Cve;
+using Dotnet.Release.CveHandler;
+
+// dotnet-cve-enricher: Agentic CLI for synthesizing, validating, and enriching .NET CVE data.
+//
+// Designed for both human and AI agent usage:
+//   --json   Emit structured JSON to stdout (for agent piping) instead of writing files
+//   --month  Operate on a single month (fine-grained; agents compose these)
+//   --all    Operate across the full tree (batch; humans use this)
+//
+// Exit codes: 0 = success, 1 = validation errors, 2 = runtime error
+
+if (args.Length < 1)
+{
+    PrintUsage();
+    return 1;
+}
+
+// Parse command and arguments
+string command = args[0].ToLowerInvariant();
+string? inputPath = null;
+bool jsonOutput = false;
+bool skipUrls = false;
+bool quietMode = false;
+string? month = null;
+bool all = false;
+
+for (int i = 1; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--json":
+            jsonOutput = true;
+            break;
+        case "--skip-urls":
+            skipUrls = true;
+            break;
+        case "--quiet" or "-q":
+            quietMode = true;
+            break;
+        case "--all":
+            all = true;
+            break;
+        case "--month" when i + 1 < args.Length:
+            month = args[++i];
+            break;
+        default:
+            if (!args[i].StartsWith('-'))
+            {
+                inputPath = args[i];
+            }
+            break;
+    }
+}
+
+if (inputPath is null)
+{
+    PrintUsage();
+    return 1;
+}
+
+try
+{
+    return command switch
+    {
+        "synthesize" => await RunSynthesize(inputPath, month, all, jsonOutput, skipUrls),
+        "validate" => await RunValidate(inputPath, skipUrls, quietMode, jsonOutput),
+        "update" => await RunUpdate(inputPath, skipUrls, jsonOutput),
+        _ => PrintUsage()
+    };
+}
+catch (Exception ex)
+{
+    if (jsonOutput)
+    {
+        WriteJsonError(ex.Message);
+    }
+    else
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+    }
+    return 2;
+}
+
+// ---- Synthesize command ----
+
+async Task<int> RunSynthesize(string releaseNotesPath, string? targetMonth, bool processAll, bool json, bool skipUrlFetch)
+{
+    if (!Directory.Exists(releaseNotesPath))
+    {
+        return ReportError($"Directory not found: {releaseNotesPath}", json);
+    }
+
+    var timelinePath = Path.Combine(releaseNotesPath, "timeline");
+    var cutoffDate = processAll ? null : FindEarliestTimelineCveDate(timelinePath);
+
+    // Scan releases.json for CVE data grouped by month
+    var releasesByCveMonth = await ScanReleasesForCves(releaseNotesPath, cutoffDate, targetMonth);
+
+    if (releasesByCveMonth.Count == 0)
+    {
+        if (json)
+        {
+            WriteSynthesizeResult(new SynthesizeResult([], 0, 0, 0));
+        }
+        else
+        {
+            Log("No months with CVE data to synthesize");
+        }
+        return 0;
+    }
+
+    var results = new List<FileResult>();
+    int createdCount = 0;
+    int skippedCount = 0;
+    int errorCount = 0;
+
+    foreach (var (yearMonth, releases) in releasesByCveMonth.OrderBy(kvp => kvp.Key))
+    {
+        try
+        {
+            var parts = yearMonth.Split('-');
+            var year = parts[0];
+            var monthStr = parts[1];
+
+            var monthDir = Path.Combine(timelinePath, year, monthStr);
+            var cveJsonPath = Path.Combine(monthDir, "cve.json");
+
+            if (File.Exists(cveJsonPath) && !processAll)
+            {
+                LogQuiet($"Skipping {yearMonth} (cve.json already exists)");
+                skippedCount++;
+                continue;
+            }
+
+            Log($"Generating cve.json for {yearMonth}...");
+
+            // Fetch MSRC data
+            Dictionary<string, MsrcCveData>? msrcData = null;
+            if (!skipUrlFetch)
+            {
+                var msrcId = MsrcClient.GetMsrcId(int.Parse(year), int.Parse(monthStr));
+                Log($"  Fetching MSRC data for {msrcId}...");
+                msrcData = await MsrcClient.FetchDataAsync(msrcId);
+            }
+
+            var cveRecords = BuildCveRecords(yearMonth, releases, msrcData);
+
+            if (json)
+            {
+                results.Add(new FileResult(cveJsonPath, cveRecords));
+            }
+            else
+            {
+                Directory.CreateDirectory(monthDir);
+                string jsonStr = JsonSerializer.Serialize(cveRecords, CveSerializerContext.Default.CveRecords);
+                await File.WriteAllTextAsync(cveJsonPath, jsonStr);
+                Log($"  Created {cveJsonPath} ({cveRecords.Disclosures.Count} CVEs from {releases.Count} releases)");
+            }
+            createdCount++;
+        }
+        catch (Exception ex)
+        {
+            Log($"  Error processing {yearMonth}: {ex.Message}");
+            errorCount++;
+        }
+    }
+
+    if (json)
+    {
+        WriteSynthesizeResult(new SynthesizeResult(results, createdCount, skippedCount, errorCount));
+    }
+    else
+    {
+        Console.WriteLine($"Summary: Created {createdCount}, Skipped {skippedCount}, Errors {errorCount}");
+    }
+
+    return errorCount > 0 ? 1 : 0;
+}
+
+// ---- Validate command ----
+
+async Task<int> RunValidate(string path, bool skipUrlChecks, bool quiet, bool json)
+{
+    var cveFiles = CveLoader.FindCveFiles(path);
+    if (cveFiles.Count == 0)
+    {
+        return ReportError($"No cve.json files found at: {path}", json);
+    }
+
+    var fileReports = new List<ValidationFileReport>();
+    int failureCount = 0;
+
+    foreach (var cveFile in cveFiles)
+    {
+        var report = await ValidateCveFile(cveFile, skipUrlChecks);
+        fileReports.Add(report);
+
+        if (report.Errors.Count > 0)
+        {
+            failureCount++;
+        }
+
+        if (!json)
+        {
+            if (report.Errors.Count == 0 && report.Warnings.Count == 0)
+            {
+                if (!quiet)
+                {
+                    Console.WriteLine($"Validating: {cveFile}");
+                    Console.WriteLine("  ✓ All validations passed");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"Validating: {cveFile}");
+                foreach (var warning in report.Warnings)
+                    Console.WriteLine($"  ⚠ {warning}");
+                foreach (var error in report.Errors)
+                    Console.WriteLine($"  ✗ {error}");
+            }
+            if (!quiet || report.Errors.Count > 0)
+            {
+                Console.WriteLine();
+            }
+        }
+    }
+
+    if (json)
+    {
+        WriteValidationResult(new ValidationResult(
+            fileReports,
+            fileReports.Count - failureCount,
+            failureCount
+        ));
+    }
+    else
+    {
+        Console.WriteLine($"Validation complete: {fileReports.Count - failureCount} succeeded, {failureCount} failed");
+    }
+
+    return failureCount > 0 ? 1 : 0;
+}
+
+// ---- Update command ----
+
+async Task<int> RunUpdate(string path, bool skipUrlChecks, bool json)
+{
+    var cveFiles = CveLoader.FindCveFiles(path);
+    if (cveFiles.Count == 0)
+    {
+        return ReportError($"No cve.json files found at: {path}", json);
+    }
+
+    var results = new List<FileResult>();
+    int successCount = 0;
+    int failureCount = 0;
+
+    foreach (var cveFile in cveFiles)
+    {
+        try
+        {
+            Log($"Updating: {cveFile}");
+
+            using var stream = File.OpenRead(cveFile);
+            var cveRecords = await CveLoader.DeserializeAsync(stream);
+
+            if (cveRecords is null)
+            {
+                Log($"  ERROR: Failed to deserialize JSON");
+                failureCount++;
+                continue;
+            }
+
+            var generated = CveDictionaryGenerator.GenerateAll(cveRecords);
+            var cveCommits = CveDictionaryGenerator.GenerateCommits(cveRecords);
+
+            IList<Cve> updatedCves = cveRecords.Disclosures;
+            if (!skipUrlChecks)
+            {
+                updatedCves = await UpdateCvssScores(cveRecords.Disclosures);
+                updatedCves = await UpdateCnaDataFromMsrc(cveFile, updatedCves);
+            }
+
+            var updated = cveRecords with
+            {
+                Disclosures = updatedCves,
+                CveReleases = generated.CveReleases,
+                ProductCves = generated.ProductCves,
+                PackageCves = generated.PackageCves,
+                ProductName = generated.ProductName,
+                ReleaseCves = generated.ReleaseCves,
+                SeverityCves = generated.SeverityCves,
+                CveCommits = cveCommits
+            };
+
+            if (json)
+            {
+                results.Add(new FileResult(cveFile, updated));
+            }
+            else
+            {
+                string jsonStr = JsonSerializer.Serialize(updated, CveSerializerContext.Default.CveRecords);
+                await File.WriteAllTextAsync(cveFile, jsonStr);
+                var updateMsg = skipUrlChecks ? "dictionaries and cve_commits" : "dictionaries, cve_commits, and CVSS scores";
+                Log($"  ✓ Updated {updateMsg}");
+            }
+            successCount++;
+        }
+        catch (Exception ex)
+        {
+            Log($"  ERROR: {ex.Message}");
+            failureCount++;
+        }
+    }
+
+    if (json)
+    {
+        WriteUpdateResult(new UpdateResult(results, successCount, failureCount));
+    }
+    else
+    {
+        Console.WriteLine($"Update complete: {successCount} succeeded, {failureCount} failed");
+    }
+
+    return failureCount > 0 ? 1 : 0;
+}
+
+// ---- Validation logic ----
+
+async Task<ValidationFileReport> ValidateCveFile(string filePath, bool skipUrlChecks)
+{
+    var errors = new List<string>();
+    var warnings = new List<string>();
+
+    try
+    {
+        using var jsonStream = File.OpenRead(filePath);
+        var cves = await CveLoader.DeserializeAsync(jsonStream);
+
+        if (cves is null)
+        {
+            errors.Add("Failed to deserialize JSON");
+            return new ValidationFileReport(filePath, errors, warnings);
+        }
+
+        ValidateTaxonomy(cves, errors);
+        ValidateVersionCoherence(cves, errors);
+        ValidateReleaseFields(cves, errors);
+        ValidateReleaseVersionFormats(cves, errors);
+        ValidateCommitKeyFormat(cves, errors);
+        ValidateForeignKeys(cves, errors, warnings);
+        ValidateDictionaries(cves, errors);
+
+        if (!skipUrlChecks)
+        {
+            await ValidateUrls(cves, errors);
+            await ValidateMsrcData(filePath, cves, errors);
+        }
+    }
+    catch (JsonException ex)
+    {
+        errors.Add($"JSON parsing error: {ex.Message}");
+    }
+    catch (Exception ex)
+    {
+        errors.Add($"Unexpected error: {ex.Message}");
+    }
+
+    return new ValidationFileReport(filePath, errors, warnings);
+}
+
+static void ValidateTaxonomy(CveRecords cves, List<string> errors)
+{
+    var validProducts = new[] { "dotnet-runtime", "dotnet-aspnetcore", "dotnet-windows-desktop", "dotnet-sdk" };
+    var validPlatforms = new[] { "linux", "macos", "windows", "all" };
+    var validArchitectures = new[] { "arm", "arm64", "x64", "x86", "all" };
+    var validSeverities = new[] { "critical", "high", "medium", "low" };
+    var validCnas = new[] { "microsoft" };
+
+    if (cves.Products is not null)
+    {
+        foreach (var product in cves.Products)
+        {
+            if (!validProducts.Contains(product.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                errors.Add($"Invalid product name: '{product.Name}'");
+            }
+        }
+    }
+
+    if (cves.Disclosures is not null)
+    {
+        foreach (var cve in cves.Disclosures)
+        {
+            if (cve.Platforms is not null)
+            {
+                foreach (var platform in cve.Platforms)
+                {
+                    if (!validPlatforms.Contains(platform, StringComparer.OrdinalIgnoreCase))
+                    {
+                        errors.Add($"Invalid platform in {cve.Id}: '{platform}'");
+                    }
+                }
+            }
+
+            if (cve.Architectures is not null)
+            {
+                foreach (var arch in cve.Architectures)
+                {
+                    if (!validArchitectures.Contains(arch, StringComparer.OrdinalIgnoreCase))
+                    {
+                        errors.Add($"Invalid architecture in {cve.Id}: '{arch}'");
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(cve.Cvss.Severity))
+            {
+                if (!validSeverities.Contains(cve.Cvss.Severity, StringComparer.OrdinalIgnoreCase))
+                {
+                    errors.Add($"Invalid severity in {cve.Id}: '{cve.Cvss.Severity}'");
+                }
+            }
+
+            if (cve.Cna is not null)
+            {
+                if (!validCnas.Any(v => string.Equals(v, cve.Cna.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    errors.Add($"Invalid CNA in {cve.Id}: '{cve.Cna.Name}'");
+                }
+            }
+        }
+    }
+}
+
+static void ValidateVersionCoherence(CveRecords cves, List<string> errors)
+{
+    if (cves.Products is not null)
+    {
+        foreach (var product in cves.Products)
+        {
+            if (!IsVersionCoherent(product.MinVulnerable, product.MaxVulnerable, product.Fixed))
+            {
+                errors.Add($"Incoherent versions for {product.CveId} in product {product.Name}: min={product.MinVulnerable}, max={product.MaxVulnerable}, fixed={product.Fixed}");
+            }
+        }
+    }
+
+    if (cves.Packages is not null)
+    {
+        foreach (var package in cves.Packages)
+        {
+            if (!IsVersionCoherent(package.MinVulnerable, package.MaxVulnerable, package.Fixed))
+            {
+                errors.Add($"Incoherent versions for {package.CveId} in package {package.Name}: min={package.MinVulnerable}, max={package.MaxVulnerable}, fixed={package.Fixed}");
+            }
+        }
+    }
+}
+
+static void ValidateReleaseFields(CveRecords cves, List<string> errors)
+{
+    if (cves.Products is not null)
+    {
+        foreach (var product in cves.Products)
+        {
+            if (string.IsNullOrEmpty(product.Release))
+            {
+                errors.Add($"Product '{product.Name}' for {product.CveId} has null or empty release field");
+            }
+        }
+    }
+}
+
+static void ValidateReleaseVersionFormats(CveRecords cves, List<string> errors)
+{
+    if (cves.Products is not null)
+    {
+        foreach (var product in cves.Products)
+        {
+            if (!string.IsNullOrEmpty(product.Release) && !IsTwoPartVersion(product.Release))
+            {
+                errors.Add($"Product '{product.Name}' for {product.CveId} has invalid release version '{product.Release}' (must be two-part like '9.0')");
+            }
+        }
+    }
+}
+
+static void ValidateCommitKeyFormat(CveRecords cves, List<string> errors)
+{
+    if (cves.Commits is null) return;
+
+    var commitKeyPattern = new Regex(@"^([a-zA-Z0-9-]+)@([a-f0-9]{7})$", RegexOptions.IgnoreCase);
+
+    foreach (var kvp in cves.Commits)
+    {
+        var key = kvp.Key;
+        var commit = kvp.Value;
+
+        var match = commitKeyPattern.Match(key);
+        if (!match.Success)
+        {
+            errors.Add($"Commit key '{key}' has invalid format (expected: repo@short_hash)");
+            continue;
+        }
+
+        var keyRepo = match.Groups[1].Value;
+        var keyShortHash = match.Groups[2].Value;
+
+        if (!string.Equals(keyRepo, commit.Repo, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add($"Commit key '{key}' repo mismatch: key='{keyRepo}', commit='{commit.Repo}'");
+        }
+
+        if (!commit.Hash.StartsWith(keyShortHash, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add($"Commit key '{key}' hash mismatch: key='{keyShortHash}', hash='{commit.Hash}'");
+        }
+    }
+}
+
+static void ValidateForeignKeys(CveRecords cves, List<string> errors, List<string> warnings)
+{
+    var cveIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (cves.Disclosures is not null)
+    {
+        foreach (var cve in cves.Disclosures) cveIds.Add(cve.Id);
+    }
+
+    var commitHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (cves.Commits is not null)
+    {
+        foreach (var commit in cves.Commits.Keys) commitHashes.Add(commit);
+    }
+
+    if (cves.Products is not null)
+    {
+        foreach (var product in cves.Products)
+        {
+            if (!cveIds.Contains(product.CveId))
+                errors.Add($"Product '{product.Name}' references unknown CVE: {product.CveId}");
+
+            if (cves.Commits is not null)
+            {
+                if (product.Commits is null)
+                    errors.Add($"Product '{product.Name}' for {product.CveId} has null commits");
+                else if (product.Commits.Count == 0)
+                    errors.Add($"Product '{product.Name}' for {product.CveId} has empty commits");
+                else
+                {
+                    foreach (var commit in product.Commits)
+                    {
+                        if (string.IsNullOrWhiteSpace(commit))
+                            errors.Add($"Product '{product.Name}' for {product.CveId} has empty commit hash");
+                        else if (!commitHashes.Contains(commit))
+                            warnings.Add($"Product '{product.Name}' for {product.CveId} references commit not in .commits: {commit}");
+                    }
+                }
+            }
+        }
+    }
+
+    if (cves.Packages is not null)
+    {
+        foreach (var package in cves.Packages)
+        {
+            if (!cveIds.Contains(package.CveId))
+                errors.Add($"Package '{package.Name}' references unknown CVE: {package.CveId}");
+
+            if (cves.Commits is not null)
+            {
+                if (package.Commits is null)
+                    errors.Add($"Package '{package.Name}' for {package.CveId} has null commits");
+                else if (package.Commits.Count == 0)
+                    errors.Add($"Package '{package.Name}' for {package.CveId} has empty commits");
+                else
+                {
+                    foreach (var commit in package.Commits)
+                    {
+                        if (string.IsNullOrWhiteSpace(commit))
+                            errors.Add($"Package '{package.Name}' for {package.CveId} has empty commit hash");
+                        else if (!commitHashes.Contains(commit))
+                            warnings.Add($"Package '{package.Name}' for {package.CveId} references commit not in .commits: {commit}");
+                    }
+                }
+            }
+        }
+    }
+
+    // Validate cve_commits references
+    if (cves.CveCommits is not null)
+    {
+        foreach (var kvp in cves.CveCommits)
+        {
+            if (!cveIds.Contains(kvp.Key))
+                errors.Add($"cve_commits references unknown CVE: {kvp.Key}");
+            foreach (var commitHash in kvp.Value)
+            {
+                if (!commitHashes.Contains(commitHash))
+                    errors.Add($"CVE {kvp.Key} references unknown commit: {commitHash}");
+            }
+        }
+    }
+
+    // Check orphans
+    var referencedCves = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (cves.Products is not null)
+        foreach (var p in cves.Products) referencedCves.Add(p.CveId);
+    if (cves.Packages is not null)
+        foreach (var p in cves.Packages) referencedCves.Add(p.CveId);
+
+    foreach (var cveId in cveIds)
+    {
+        if (!referencedCves.Contains(cveId))
+            errors.Add($"CVE {cveId} is not referenced by any product or package");
+    }
+
+    var referencedCommits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (cves.CveCommits is not null)
+    {
+        foreach (var kvp in cves.CveCommits)
+            foreach (var c in kvp.Value) referencedCommits.Add(c);
+    }
+
+    foreach (var ch in commitHashes)
+    {
+        if (!referencedCommits.Contains(ch))
+            errors.Add($"Commit {ch} is not referenced by any CVE");
+    }
+}
+
+static void ValidateDictionaries(CveRecords cveRecords, List<string> errors)
+{
+    var expected = CveDictionaryGenerator.GenerateAll(cveRecords);
+
+    ValidateDictionary(cveRecords.CveReleases, expected.CveReleases, "cve_releases", errors);
+    ValidateDictionary(cveRecords.ProductCves, expected.ProductCves, "product_cves", errors);
+    ValidateDictionary(cveRecords.PackageCves, expected.PackageCves, "package_cves", errors);
+    ValidateDictionary(cveRecords.ProductName, expected.ProductName, "product_name", errors);
+    ValidateDictionary(cveRecords.ReleaseCves, expected.ReleaseCves, "release_cves", errors);
+    ValidateDictionary(cveRecords.SeverityCves, expected.SeverityCves, "severity_cves", errors);
+
+    var expectedCveCommits = CveDictionaryGenerator.GenerateCommits(cveRecords);
+    if (expectedCveCommits.Count > 0)
+    {
+        ValidateDictionary(cveRecords.CveCommits, expectedCveCommits, "cve_commits", errors);
+    }
+}
+
+static void ValidateDictionary<T>(
+    IDictionary<string, T>? actual,
+    IDictionary<string, T>? expected,
+    string dictionaryName,
+    List<string> errors)
+{
+    if (expected is null && actual is null) return;
+
+    if (expected is null || actual is null)
+    {
+        errors.Add($"{dictionaryName}: Dictionary is {(actual is null ? "missing" : "unexpected")}");
+        return;
+    }
+
+    foreach (var key in expected.Keys)
+    {
+        if (!actual.ContainsKey(key))
+            errors.Add($"{dictionaryName}: Missing key '{key}'");
+    }
+
+    foreach (var key in actual.Keys)
+    {
+        if (!expected.ContainsKey(key))
+            errors.Add($"{dictionaryName}: Unexpected key '{key}'");
+    }
+
+    foreach (var key in expected.Keys.Intersect(actual.Keys))
+    {
+        var expectedValue = expected[key];
+        var actualValue = actual[key];
+
+        if (expectedValue is IList<string> expectedList && actualValue is IList<string> actualList)
+        {
+            var expectedSorted = expectedList.OrderBy(x => x).ToList();
+            var actualSorted = actualList.OrderBy(x => x).ToList();
+
+            if (!expectedSorted.SequenceEqual(actualSorted))
+            {
+                errors.Add($"{dictionaryName}['{key}']: Expected [{string.Join(", ", expectedSorted)}], got [{string.Join(", ", actualSorted)}]");
+            }
+        }
+        else if (!Equals(expectedValue, actualValue))
+        {
+            errors.Add($"{dictionaryName}['{key}']: Expected {expectedValue}, got {actualValue}");
+        }
+    }
+}
+
+static async Task ValidateUrls(CveRecords cves, List<string> errors)
+{
+    using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+    client.DefaultRequestHeaders.Add("User-Agent", "dotnet-cve-enricher/0.1");
+
+    var urls = new HashSet<string>();
+    if (cves.Disclosures is not null)
+    {
+        foreach (var cve in cves.Disclosures)
+        {
+            if (cve.References is not null)
+            {
+                foreach (var url in cve.References) urls.Add(url);
+            }
+        }
+    }
+    if (cves.Commits is not null)
+    {
+        foreach (var commit in cves.Commits.Values) urls.Add(commit.Url);
+    }
+
+    var tasks = urls.Select(url => ValidateSingleUrl(client, url));
+    var results = await Task.WhenAll(tasks);
+    foreach (var error in results.Where(e => e is not null))
+    {
+        errors.Add(error!);
+    }
+}
+
+static async Task<string?> ValidateSingleUrl(HttpClient client, string url)
+{
+    try
+    {
+        var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+        return response.IsSuccessStatusCode ? null : $"URL returned {(int)response.StatusCode}: {url}";
+    }
+    catch (HttpRequestException ex)
+    {
+        return $"URL request failed: {url} - {ex.Message}";
+    }
+    catch (TaskCanceledException)
+    {
+        return $"URL request timeout: {url}";
+    }
+}
+
+static async Task ValidateMsrcData(string filePath, CveRecords cves, List<string> errors)
+{
+    var msrcId = MsrcClient.GetMsrcIdFromPath(filePath);
+    if (msrcId is null) return;
+
+    var msrcData = await MsrcClient.FetchDataAsync(msrcId);
+    if (msrcData is null)
+    {
+        errors.Add("MSRC: Could not fetch MSRC data");
+        return;
+    }
+
+    foreach (var cve in cves.Disclosures)
+    {
+        if (msrcData.TryGetValue(cve.Id, out var msrcCve))
+        {
+            if (cve.Cvss.Score != msrcCve.Score)
+                errors.Add($"MSRC: {cve.Id} score mismatch - Expected: {msrcCve.Score}, Actual: {cve.Cvss.Score}");
+            if (cve.Cvss.Vector != msrcCve.Vector)
+                errors.Add($"MSRC: {cve.Id} vector mismatch");
+            if (cve.Weakness != msrcCve.Weakness)
+                errors.Add($"MSRC: {cve.Id} weakness/CWE mismatch");
+            if (!string.IsNullOrEmpty(msrcCve.Impact))
+            {
+                var actualImpact = cve.Cna?.Impact;
+                if (string.IsNullOrEmpty(actualImpact))
+                    errors.Add($"MSRC: {cve.Id} missing cna.impact - Expected: '{msrcCve.Impact}'");
+                else if (actualImpact != msrcCve.Impact)
+                    errors.Add($"MSRC: {cve.Id} cna.impact mismatch");
+            }
+        }
+    }
+}
+
+// ---- Update helpers ----
+
+static async Task<IList<Cve>> UpdateCvssScores(IList<Cve> cves)
+{
+    var updatedCves = new List<Cve>();
+    using var client = new HttpClient();
+    client.DefaultRequestHeaders.Add("User-Agent", "dotnet-cve-enricher/0.1");
+
+    foreach (var cve in cves)
+    {
+        try
+        {
+            var response = await client.GetStringAsync($"https://cveawg.mitre.org/api/cve/{cve.Id}");
+            var jsonDoc = JsonDocument.Parse(response);
+
+            decimal baseScore = 0.0m;
+            string baseSeverity = "";
+            string? weakness = null;
+
+            if (jsonDoc.RootElement.TryGetProperty("containers", out var containers) &&
+                containers.TryGetProperty("cna", out var cna))
+            {
+                if (cna.TryGetProperty("metrics", out var metrics) && metrics.GetArrayLength() > 0)
+                {
+                    var firstMetric = metrics[0];
+                    if (firstMetric.TryGetProperty("cvssV3_1", out var cvssV3_1))
+                    {
+                        baseScore = cvssV3_1.TryGetProperty("baseScore", out var se) ? se.GetDecimal() : 0.0m;
+                        baseSeverity = cvssV3_1.TryGetProperty("baseSeverity", out var sv) ? sv.GetString() ?? "" : "";
+                    }
+                }
+
+                if (cna.TryGetProperty("problemTypes", out var problemTypes) && problemTypes.GetArrayLength() > 0)
+                {
+                    var firstProblem = problemTypes[0];
+                    if (firstProblem.TryGetProperty("descriptions", out var descriptions) && descriptions.GetArrayLength() > 0)
+                    {
+                        if (descriptions[0].TryGetProperty("cweId", out var cweIdElement))
+                        {
+                            weakness = cweIdElement.GetString();
+                        }
+                    }
+                }
+            }
+
+            var updatedCvss = cve.Cvss with { Score = baseScore, Severity = baseSeverity };
+            updatedCves.Add(cve with { Cvss = updatedCvss, Weakness = weakness });
+        }
+        catch
+        {
+            updatedCves.Add(cve);
+        }
+
+        await Task.Delay(500); // Rate limiting
+    }
+
+    return updatedCves;
+}
+
+static async Task<IList<Cve>> UpdateCnaDataFromMsrc(string filePath, IList<Cve> cves)
+{
+    var msrcId = MsrcClient.GetMsrcIdFromPath(filePath);
+    if (msrcId is null) return cves;
+
+    var msrcData = await MsrcClient.FetchDataAsync(msrcId);
+    if (msrcData is null) return cves;
+
+    var updatedCves = new List<Cve>();
+    foreach (var cve in cves)
+    {
+        if (msrcData.TryGetValue(cve.Id, out var msrcCve))
+        {
+            var updatedCna = cve.Cna ?? new Cna("microsoft");
+            bool hasUpdates = false;
+
+            if (!string.IsNullOrEmpty(msrcCve.CnaSeverity))
+            {
+                updatedCna = updatedCna with { Severity = msrcCve.CnaSeverity };
+                hasUpdates = true;
+            }
+            if (!string.IsNullOrEmpty(msrcCve.Impact))
+            {
+                updatedCna = updatedCna with { Impact = msrcCve.Impact };
+                hasUpdates = true;
+            }
+            if (msrcCve.Acknowledgments is { Count: > 0 })
+            {
+                updatedCna = updatedCna with { Acknowledgments = msrcCve.Acknowledgments };
+                hasUpdates = true;
+            }
+            if (msrcCve.Faqs is { Count: > 0 })
+            {
+                updatedCna = updatedCna with { Faq = msrcCve.Faqs };
+                hasUpdates = true;
+            }
+
+            updatedCves.Add(hasUpdates ? cve with { Cna = updatedCna } : cve);
+        }
+        else
+        {
+            updatedCves.Add(cve);
+        }
+    }
+
+    return updatedCves;
+}
+
+// ---- Synthesize helpers ----
+
+static async Task<Dictionary<string, List<ReleaseWithCves>>> ScanReleasesForCves(
+    string releaseNotesPath, DateOnly? cutoffDate, string? targetMonth)
+{
+    var releasesByCveMonth = new Dictionary<string, List<ReleaseWithCves>>();
+
+    foreach (var majorVersionDir in Directory.GetDirectories(releaseNotesPath))
+    {
+        var majorVersion = Path.GetFileName(majorVersionDir);
+        if (!majorVersion.Contains('.') || majorVersion == "timeline") continue;
+
+        var releasesJsonPath = Path.Combine(majorVersionDir, "releases.json");
+        if (!File.Exists(releasesJsonPath)) continue;
+
+        try
+        {
+            var releasesJson = await File.ReadAllTextAsync(releasesJsonPath);
+            var releasesDoc = JsonDocument.Parse(releasesJson);
+
+            if (!releasesDoc.RootElement.TryGetProperty("releases", out var releasesArray)) continue;
+
+            foreach (var release in releasesArray.EnumerateArray())
+            {
+                if (!release.TryGetProperty("release-date", out var releaseDateProp)) continue;
+                var releaseDateStr = releaseDateProp.GetString();
+                if (string.IsNullOrEmpty(releaseDateStr) || !DateOnly.TryParse(releaseDateStr, out var releaseDate)) continue;
+
+                if (cutoffDate != null && releaseDate >= cutoffDate.Value) continue;
+
+                var yearMonth = $"{releaseDate.Year:D4}-{releaseDate.Month:D2}";
+                if (targetMonth != null && yearMonth != targetMonth) continue;
+
+                if (!release.TryGetProperty("cve-list", out var cveListArray)) continue;
+                if (cveListArray.ValueKind == JsonValueKind.Null || cveListArray.GetArrayLength() == 0) continue;
+
+                if (!release.TryGetProperty("release-version", out var versionProp)) continue;
+                var version = versionProp.GetString();
+                if (string.IsNullOrEmpty(version)) continue;
+
+                var cveIds = new List<string>();
+                foreach (var cveEntry in cveListArray.EnumerateArray())
+                {
+                    if (cveEntry.TryGetProperty("cve-id", out var cveIdProp))
+                    {
+                        var cveId = cveIdProp.GetString();
+                        if (!string.IsNullOrEmpty(cveId)) cveIds.Add(cveId);
+                    }
+                }
+                if (cveIds.Count == 0) continue;
+
+                if (!releasesByCveMonth.ContainsKey(yearMonth))
+                {
+                    releasesByCveMonth[yearMonth] = [];
+                }
+
+                releasesByCveMonth[yearMonth].Add(new ReleaseWithCves(version, majorVersion, releaseDate, cveIds));
+            }
+        }
+        catch
+        {
+            // Skip unparseable releases.json
+        }
+    }
+
+    return releasesByCveMonth;
+}
+
+static DateOnly? FindEarliestTimelineCveDate(string timelinePath)
+{
+    if (!Directory.Exists(timelinePath)) return null;
+
+    DateOnly? earliest = null;
+
+    foreach (var yearDir in Directory.GetDirectories(timelinePath))
+    {
+        if (!int.TryParse(Path.GetFileName(yearDir), out var yearNum)) continue;
+
+        foreach (var monthDir in Directory.GetDirectories(yearDir))
+        {
+            if (!int.TryParse(Path.GetFileName(monthDir), out var monthNum)) continue;
+
+            if (File.Exists(Path.Combine(monthDir, "cve.json")))
+            {
+                var date = new DateOnly(yearNum, monthNum, 1);
+                if (earliest is null || date < earliest.Value) earliest = date;
+            }
+        }
+    }
+
+    return earliest;
+}
+
+static CveRecords BuildCveRecords(string yearMonth, List<ReleaseWithCves> releases, Dictionary<string, MsrcCveData>? msrcData)
+{
+    var parts = yearMonth.Split('-');
+    var year = int.Parse(parts[0]);
+    var month = int.Parse(parts[1]);
+    var monthName = new DateTime(year, month, 1).ToString("MMMM");
+
+    var allCveIds = releases.SelectMany(r => r.CveIds).Distinct().OrderBy(id => id).ToList();
+
+    var disclosures = new List<Cve>();
+    foreach (var cveId in allCveIds)
+    {
+        MsrcCveData? msrcCve = null;
+        msrcData?.TryGetValue(cveId, out msrcCve);
+
+        var earliestRelease = releases
+            .Where(r => r.CveIds.Contains(cveId))
+            .OrderBy(r => r.ReleaseDate)
+            .First();
+
+        var cvss = new Cvss(
+            Version: "3.1",
+            Vector: msrcCve?.Vector ?? "",
+            Score: msrcCve?.Score ?? 0.0m,
+            Severity: "",
+            Source: "microsoft"
+        );
+
+        var timeline = new Timeline(
+            Disclosure: new Event(earliestRelease.ReleaseDate, "Publicly disclosed"),
+            Fixed: new Event(earliestRelease.ReleaseDate, $"Fixed in {earliestRelease.Version}")
+        );
+
+        Cna? cna = null;
+        if (msrcCve is not null &&
+            (!string.IsNullOrEmpty(msrcCve.Impact) ||
+             !string.IsNullOrEmpty(msrcCve.CnaSeverity) ||
+             msrcCve.Acknowledgments is not null ||
+             msrcCve.Faqs is not null))
+        {
+            cna = new Cna(
+                Name: "microsoft",
+                Severity: msrcCve.CnaSeverity,
+                Impact: msrcCve.Impact,
+                Acknowledgments: msrcCve.Acknowledgments,
+                Faq: msrcCve.Faqs
+            );
+        }
+
+        disclosures.Add(new Cve(
+            Id: cveId,
+            Problem: msrcCve?.Impact ?? "Security Vulnerability",
+            Description: [$"A security vulnerability exists in .NET. See {cveId} for details."],
+            Cvss: cvss,
+            Timeline: timeline,
+            Platforms: ["all"],
+            Architectures: ["all"],
+            References:
+            [
+                $"https://msrc.microsoft.com/update-guide/vulnerability/{cveId}",
+                $"https://nvd.nist.gov/vuln/detail/{cveId}"
+            ],
+            Weakness: msrcCve?.Weakness,
+            Cna: cna
+        ));
+    }
+
+    var products = new List<Product>();
+    foreach (var release in releases)
+    {
+        foreach (var cveId in release.CveIds)
+        {
+            products.Add(new Product(
+                CveId: cveId,
+                Name: "dotnet-runtime",
+                MinVulnerable: release.MajorVersion,
+                MaxVulnerable: release.Version,
+                Fixed: release.Version,
+                Release: release.MajorVersion,
+                Commits: []
+            ));
+        }
+    }
+
+    var generated = CveDictionaryGenerator.GenerateAll(new CveRecords(
+        LastUpdated: "",
+        Title: "",
+        Disclosures: disclosures,
+        Products: products,
+        Packages: []
+    ));
+
+    return new CveRecords(
+        LastUpdated: DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+        Title: $".NET {monthName} {year}",
+        Disclosures: disclosures,
+        Products: products,
+        Packages: [],
+        Commits: null,
+        ProductName: generated.ProductName,
+        ProductCves: generated.ProductCves,
+        PackageCves: generated.PackageCves,
+        ReleaseCves: generated.ReleaseCves,
+        SeverityCves: generated.SeverityCves,
+        CveReleases: generated.CveReleases,
+        CveCommits: null
+    );
+}
+
+// ---- Shared helpers ----
+
+static bool IsVersionCoherent(string minVersion, string maxVersion, string fixedVersion)
+{
+    try
+    {
+        var min = ParseSemVer(minVersion);
+        var max = ParseSemVer(maxVersion);
+        var fix = ParseSemVer(fixedVersion);
+        if (!min.HasValue || !max.HasValue || !fix.HasValue) return true;
+        return CompareSemVer(min.Value, max.Value) <= 0 && CompareSemVer(max.Value, fix.Value) < 0;
+    }
+    catch
+    {
+        return true;
+    }
+}
+
+static (Version version, string? prerelease)? ParseSemVer(string versionString)
+{
+    try
+    {
+        int dashIndex = versionString.IndexOf('-');
+        string versionPart = dashIndex > 0 ? versionString[..dashIndex] : versionString;
+        string? prerelease = dashIndex > 0 ? versionString[(dashIndex + 1)..] : null;
+        return Version.TryParse(versionPart, out var version) ? (version, prerelease) : null;
+    }
+    catch
+    {
+        return null;
+    }
+}
+
+static int CompareSemVer((Version version, string? prerelease) a, (Version version, string? prerelease) b)
+{
+    int versionCompare = a.version.CompareTo(b.version);
+    if (versionCompare != 0) return versionCompare;
+
+    if (a.prerelease is null && b.prerelease is null) return 0;
+    if (a.prerelease is null) return 1;
+    if (b.prerelease is null) return -1;
+    return string.Compare(a.prerelease, b.prerelease, StringComparison.OrdinalIgnoreCase);
+}
+
+static bool IsTwoPartVersion(string version)
+{
+    var parts = version.Split('.');
+    return parts.Length == 2 && int.TryParse(parts[0], out _) && int.TryParse(parts[1], out _);
+}
+
+void Log(string message) => Console.Error.WriteLine(message);
+void LogQuiet(string message) => Console.Error.WriteLine(message);
+
+static int ReportError(string message, bool json)
+{
+    if (json)
+    {
+        WriteJsonError(message);
+    }
+    else
+    {
+        Console.Error.WriteLine($"Error: {message}");
+    }
+    return 2;
+}
+
+static void WriteJsonError(string message) =>
+    Console.WriteLine(JsonSerializer.Serialize(new ErrorResult(message), ToolJsonContext.Default.ErrorResult));
+
+static void WriteSynthesizeResult(SynthesizeResult data) =>
+    Console.WriteLine(JsonSerializer.Serialize(data, ToolJsonContext.Default.SynthesizeResult));
+
+static void WriteValidationResult(ValidationResult data) =>
+    Console.WriteLine(JsonSerializer.Serialize(data, ToolJsonContext.Default.ValidationResult));
+
+static void WriteUpdateResult(UpdateResult data) =>
+    Console.WriteLine(JsonSerializer.Serialize(data, ToolJsonContext.Default.UpdateResult));
+
+static int PrintUsage()
+{
+    Console.Error.WriteLine("""
+        dotnet-cve-enricher: Synthesize, validate, and enrich .NET CVE disclosure data.
+
+        Usage:
+          dotnet-cve-enricher synthesize <release-notes-path> [options]
+          dotnet-cve-enricher validate <path> [options]
+          dotnet-cve-enricher update <path> [options]
+
+        Synthesize options:
+          --month <YYYY-MM>  Synthesize one month only
+          --all              Synthesize all months (even if cve.json exists)
+          --skip-urls        Skip MSRC API calls (faster, offline)
+          --json             Emit generated records as JSON to stdout
+
+        Validate options:
+          --skip-urls        Skip URL and MSRC validation
+          --quiet, -q        Only show files with errors
+          --json             Emit structured validation report as JSON
+
+        Update options:
+          --skip-urls        Skip CVE.org and MSRC API calls
+          --json             Emit updated records as JSON (no file write)
+
+        Exit codes:
+          0  Success
+          1  Validation errors found
+          2  Runtime error
+
+        Examples:
+          dotnet-cve-enricher synthesize ~/git/core/release-notes
+          dotnet-cve-enricher synthesize ~/git/core/release-notes --month 2024-03 --json
+          dotnet-cve-enricher validate ~/git/core/release-notes/timeline --skip-urls -q
+          dotnet-cve-enricher update ~/git/core/release-notes/timeline/2025/01/cve.json --json
+        """);
+    return 1;
+}
+
+// ---- JSON output types ----
+
+record FileResult(string Path, CveRecords Content);
+record SynthesizeResult(List<FileResult> Files, int Created, int Skipped, int Errors);
+record ValidationFileReport(string Path, List<string> Errors, List<string> Warnings);
+record ValidationResult(List<ValidationFileReport> Files, int Succeeded, int Failed);
+record UpdateResult(List<FileResult> Files, int Succeeded, int Failed);
+record ErrorResult(string Error);
+record ReleaseWithCves(string Version, string MajorVersion, DateOnly ReleaseDate, List<string> CveIds);
+
+// JSON serializer context for tool output (AOT-compatible)
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
+[JsonSerializable(typeof(SynthesizeResult))]
+[JsonSerializable(typeof(ValidationResult))]
+[JsonSerializable(typeof(UpdateResult))]
+[JsonSerializable(typeof(ErrorResult))]
+partial class ToolJsonContext : JsonSerializerContext
+{
+}

--- a/src/Dotnet.Release.CveHandler/CveDictionaryGenerator.cs
+++ b/src/Dotnet.Release.CveHandler/CveDictionaryGenerator.cs
@@ -1,0 +1,234 @@
+using System.Globalization;
+using Dotnet.Release.Cve;
+using CveRecord = Dotnet.Release.Cve.Cve;
+
+namespace Dotnet.Release.CveHandler;
+
+/// <summary>
+/// Generates lookup dictionaries from CVE records for efficient querying.
+/// </summary>
+public static class CveDictionaryGenerator
+{
+    private static readonly StringComparer NumericComparer =
+        StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+
+    /// <summary>
+    /// Generates all lookup dictionaries from CVE records.
+    /// </summary>
+    public static GeneratedDictionaries GenerateAll(CveRecords cveRecords)
+    {
+        var productName = new Dictionary<string, string>();
+        var productCves = new Dictionary<string, List<string>>();
+        var packageCves = new Dictionary<string, List<string>>();
+        var cveReleases = new Dictionary<string, List<string>>();
+        var releaseCves = new Dictionary<string, List<string>>();
+        var severityCves = InitializeSeverityDictionary();
+
+        var validCveIds = new HashSet<string>(cveRecords.Disclosures.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var product in cveRecords.Products)
+        {
+            if (!productName.ContainsKey(product.Name))
+            {
+                productName[product.Name] = ProductNameHelper.GetDisplayName(product.Name);
+            }
+
+            if (validCveIds.Contains(product.CveId))
+            {
+                if (!productCves.ContainsKey(product.Name))
+                {
+                    productCves[product.Name] = [];
+                }
+                if (!productCves[product.Name].Contains(product.CveId))
+                {
+                    productCves[product.Name].Add(product.CveId);
+                }
+
+                if (!string.IsNullOrEmpty(product.Release))
+                {
+                    string release = product.Release;
+
+                    if (!cveReleases.ContainsKey(product.CveId))
+                    {
+                        cveReleases[product.CveId] = [];
+                    }
+                    if (!cveReleases[product.CveId].Contains(release))
+                    {
+                        cveReleases[product.CveId].Add(release);
+                    }
+
+                    if (!releaseCves.ContainsKey(release))
+                    {
+                        releaseCves[release] = [];
+                    }
+                    if (!releaseCves[release].Contains(product.CveId))
+                    {
+                        releaseCves[release].Add(product.CveId);
+                    }
+                }
+            }
+        }
+
+        foreach (var package in cveRecords.Packages)
+        {
+            if (validCveIds.Contains(package.CveId))
+            {
+                if (!packageCves.ContainsKey(package.Name))
+                {
+                    packageCves[package.Name] = [];
+                }
+                if (!packageCves[package.Name].Contains(package.CveId))
+                {
+                    packageCves[package.Name].Add(package.CveId);
+                }
+
+                if (!string.IsNullOrEmpty(package.Release))
+                {
+                    string release = package.Release;
+
+                    if (!cveReleases.ContainsKey(package.CveId))
+                    {
+                        cveReleases[package.CveId] = [];
+                    }
+                    if (!cveReleases[package.CveId].Contains(release))
+                    {
+                        cveReleases[package.CveId].Add(release);
+                    }
+
+                    if (!releaseCves.ContainsKey(release))
+                    {
+                        releaseCves[release] = [];
+                    }
+                    if (!releaseCves[release].Contains(package.CveId))
+                    {
+                        releaseCves[release].Add(package.CveId);
+                    }
+                }
+            }
+        }
+
+        foreach (var disclosure in cveRecords.Disclosures)
+        {
+            AddSeverityMappings(severityCves, disclosure.Id, disclosure.Cvss.Severity);
+        }
+
+        foreach (var list in productCves.Values) list.Sort(NumericComparer);
+        foreach (var list in packageCves.Values) list.Sort(NumericComparer);
+        foreach (var list in cveReleases.Values) list.Sort(NumericComparer);
+        foreach (var list in releaseCves.Values) list.Sort(NumericComparer);
+
+        return new GeneratedDictionaries(
+            CveReleases: cveReleases.OrderBy(k => k.Key, NumericComparer).ToDictionary(k => k.Key, v => (IList<string>)v.Value),
+            ProductCves: productCves.OrderBy(k => k.Key).ToDictionary(k => k.Key, v => (IList<string>)v.Value),
+            PackageCves: packageCves.OrderBy(k => k.Key).ToDictionary(k => k.Key, v => (IList<string>)v.Value),
+            ProductName: productName.OrderBy(k => k.Key).ToDictionary(k => k.Key, v => v.Value),
+            ReleaseCves: releaseCves.OrderBy(k => k.Key, NumericComparer).ToDictionary(k => k.Key, v => (IList<string>)v.Value),
+            SeverityCves: FinalizeSeverityDictionary(severityCves)
+        );
+    }
+
+    /// <summary>
+    /// Generates CVE-to-commits mapping dictionary.
+    /// </summary>
+    public static IDictionary<string, IList<string>> GenerateCommits(CveRecords cveRecords)
+    {
+        var cveCommits = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        var validCommits = cveRecords.Commits is not null
+            ? new HashSet<string>(cveRecords.Commits.Keys, StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var validCveIds = new HashSet<string>(cveRecords.Disclosures.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var product in cveRecords.Products)
+        {
+            if (validCveIds.Contains(product.CveId) && product.Commits is { Count: > 0 })
+            {
+                if (!cveCommits.ContainsKey(product.CveId))
+                {
+                    cveCommits[product.CveId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+                foreach (var commit in product.Commits)
+                {
+                    if (validCommits.Contains(commit))
+                    {
+                        cveCommits[product.CveId].Add(commit);
+                    }
+                }
+            }
+        }
+
+        foreach (var package in cveRecords.Packages)
+        {
+            if (validCveIds.Contains(package.CveId) && package.Commits is { Count: > 0 })
+            {
+                if (!cveCommits.ContainsKey(package.CveId))
+                {
+                    cveCommits[package.CveId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+                foreach (var commit in package.Commits)
+                {
+                    if (validCommits.Contains(commit))
+                    {
+                        cveCommits[package.CveId].Add(commit);
+                    }
+                }
+            }
+        }
+
+        return cveCommits
+            .OrderBy(k => k.Key, NumericComparer)
+            .ToDictionary(
+                k => k.Key,
+                v => (IList<string>)v.Value.OrderBy(c => c).ToList()
+            );
+    }
+
+    public static IDictionary<string, IList<string>> GenerateSeverityCves(IList<CveRecord> disclosures)
+    {
+        var severityCves = InitializeSeverityDictionary();
+
+        foreach (var disclosure in disclosures)
+        {
+            AddSeverityMappings(severityCves, disclosure.Id, disclosure.Cvss.Severity);
+        }
+
+        return FinalizeSeverityDictionary(severityCves);
+    }
+
+    private static readonly List<string> SeverityLevels = ["CRITICAL", "HIGH", "MEDIUM", "LOW"];
+
+    private static Dictionary<string, HashSet<string>> InitializeSeverityDictionary() =>
+        SeverityLevels.ToDictionary(level => level, _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+
+    private static void AddSeverityMappings(Dictionary<string, HashSet<string>> severityCves, string cveId, string severity)
+    {
+        if (string.IsNullOrWhiteSpace(severity))
+        {
+            return;
+        }
+
+        var normalized = severity.Trim().ToUpperInvariant();
+        if (severityCves.TryGetValue(normalized, out var cveSet))
+        {
+            cveSet.Add(cveId);
+        }
+    }
+
+    private static IDictionary<string, IList<string>> FinalizeSeverityDictionary(Dictionary<string, HashSet<string>> severityCves) =>
+        SeverityLevels.ToDictionary(
+            level => level,
+            level => (IList<string>)severityCves[level].OrderBy(id => id, NumericComparer).ToList(),
+            StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Container for generated CVE lookup dictionaries.
+/// </summary>
+public record GeneratedDictionaries(
+    IDictionary<string, IList<string>> CveReleases,
+    IDictionary<string, IList<string>> ProductCves,
+    IDictionary<string, IList<string>> PackageCves,
+    IDictionary<string, string> ProductName,
+    IDictionary<string, IList<string>> ReleaseCves,
+    IDictionary<string, IList<string>> SeverityCves
+);

--- a/src/Dotnet.Release.CveHandler/CveLoader.cs
+++ b/src/Dotnet.Release.CveHandler/CveLoader.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Dotnet.Release.Cve;
+
+namespace Dotnet.Release.CveHandler;
+
+/// <summary>
+/// Loads CVE data from JSON files.
+/// </summary>
+public static class CveLoader
+{
+    /// <summary>
+    /// Loads CVE records from a cve.json file.
+    /// </summary>
+    public static async Task<CveRecords?> LoadAsync(string cveJsonPath)
+    {
+        if (!File.Exists(cveJsonPath))
+        {
+            return null;
+        }
+
+        using var stream = File.OpenRead(cveJsonPath);
+        return await JsonSerializer.DeserializeAsync(stream, CveSerializerContext.Default.CveRecords);
+    }
+
+    /// <summary>
+    /// Loads CVE records from a directory containing cve.json.
+    /// </summary>
+    public static Task<CveRecords?> LoadFromDirectoryAsync(string directoryPath)
+    {
+        var cveJsonPath = Path.Combine(directoryPath, "cve.json");
+        return LoadAsync(cveJsonPath);
+    }
+
+    /// <summary>
+    /// Loads CVE records from the timeline directory for a specific release date.
+    /// </summary>
+    public static Task<CveRecords?> LoadForReleaseDateAsync(string releaseNotesRoot, DateTimeOffset releaseDate)
+    {
+        var year = releaseDate.Year.ToString("D4");
+        var month = releaseDate.Month.ToString("D2");
+        var timelinePath = Path.Combine(releaseNotesRoot, "timeline", year, month);
+        return LoadFromDirectoryAsync(timelinePath);
+    }
+
+    /// <summary>
+    /// Finds all cve.json files under a path (single file or directory tree).
+    /// </summary>
+    public static List<string> FindCveFiles(string path)
+    {
+        if (File.Exists(path))
+        {
+            return path.EndsWith("cve.json", StringComparison.OrdinalIgnoreCase)
+                ? [path]
+                : [];
+        }
+
+        if (Directory.Exists(path))
+        {
+            var files = Directory.GetFiles(path, "cve.json", SearchOption.AllDirectories).ToList();
+            files.Sort(StringComparer.Ordinal);
+            return files;
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Deserializes CVE records from a stream.
+    /// </summary>
+    public static ValueTask<CveRecords?> DeserializeAsync(Stream json) =>
+        JsonSerializer.DeserializeAsync(json, CveSerializerContext.Default.CveRecords);
+}

--- a/src/Dotnet.Release.CveHandler/CveTransformer.cs
+++ b/src/Dotnet.Release.CveHandler/CveTransformer.cs
@@ -1,0 +1,181 @@
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.CveHandler;
+
+/// <summary>
+/// Transforms CVE data between different formats (full disclosures to summaries).
+/// </summary>
+public static class CveTransformer
+{
+    /// <summary>
+    /// Converts full CVE disclosure records to summary format for embedding in indexes.
+    /// </summary>
+    public static List<CveRecordSummary> ToSummaries(CveRecords cveRecords)
+    {
+        if (cveRecords.Disclosures is null or { Count: 0 })
+        {
+            return [];
+        }
+
+        return cveRecords.Disclosures.Select(disclosure =>
+        {
+            var affectedProducts = cveRecords.ProductCves?
+                .Where(kv => kv.Value.Contains(disclosure.Id))
+                .Select(kv => kv.Key)
+                .ToList();
+
+            var affectedPackages = cveRecords.PackageCves?
+                .Where(kv => kv.Value.Contains(disclosure.Id))
+                .Select(kv => kv.Key)
+                .ToList();
+
+            var links = new Dictionary<string, object>();
+            var announcementUrl = disclosure.References?.FirstOrDefault();
+            if (announcementUrl != null)
+            {
+                links["self"] = new HalLink(announcementUrl);
+            }
+
+            return new CveRecordSummary(disclosure.Id, disclosure.Problem)
+            {
+                Links = links.Count > 0 ? links : null,
+                CvssScore = disclosure.Cvss.Score,
+                CvssSeverity = disclosure.Cvss.Severity,
+                DisclosureDate = disclosure.Timeline.Disclosure.Date,
+                AffectedReleases = cveRecords.CveReleases?.TryGetValue(disclosure.Id, out var releases) == true
+                    ? releases
+                    : null,
+                AffectedProducts = affectedProducts?.Count > 0 ? affectedProducts : null,
+                AffectedPackages = affectedPackages?.Count > 0 ? affectedPackages : null,
+                Platforms = disclosure.Platforms
+            };
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Extracts just the CVE IDs from CVE records.
+    /// </summary>
+    public static List<string> ExtractCveIds(CveRecords? cveRecords)
+    {
+        if (cveRecords?.Disclosures is null or { Count: 0 })
+        {
+            return [];
+        }
+
+        return cveRecords.Disclosures.Select(d => d.Id).ToList();
+    }
+
+    /// <summary>
+    /// Filters CVE records to only include those affecting a specific release version.
+    /// </summary>
+    public static CveRecords? FilterByRelease(CveRecords? cveRecords, string releaseVersion)
+    {
+        if (cveRecords is null or { Disclosures.Count: 0 })
+        {
+            return null;
+        }
+
+        var cveIds = cveRecords.ReleaseCves?.TryGetValue(releaseVersion, out var ids) == true
+            ? ids.ToHashSet()
+            : new HashSet<string>();
+
+        if (cveIds.Count == 0)
+        {
+            return null;
+        }
+
+        var filteredDisclosures = cveRecords.Disclosures
+            .Where(d => cveIds.Contains(d.Id))
+            .ToList();
+
+        if (filteredDisclosures.Count == 0)
+        {
+            return null;
+        }
+
+        var filteredProducts = cveRecords.Products
+            .Where(p => cveIds.Contains(p.CveId) && p.Release == releaseVersion)
+            .ToList();
+
+        var filteredPackages = cveRecords.Packages
+            .Where(p => cveIds.Contains(p.CveId) && p.Release == releaseVersion)
+            .ToList();
+
+        var neededCommitHashes = filteredProducts.SelectMany(p => p.Commits)
+            .Concat(filteredPackages.SelectMany(p => p.Commits))
+            .ToHashSet();
+
+        var filteredCommits = cveRecords.Commits?
+            .Where(kv => neededCommitHashes.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        var filteredProductCves = filteredProducts
+            .GroupBy(p => p.Name)
+            .ToDictionary(
+                g => g.Key,
+                g => (IList<string>)g.Select(p => p.CveId).Distinct().ToList()
+            );
+
+        var filteredPackageCves = filteredPackages
+            .GroupBy(p => p.Name)
+            .ToDictionary(
+                g => g.Key,
+                g => (IList<string>)g.Select(p => p.CveId).Distinct().ToList()
+            );
+
+        var filteredCveCommits = cveRecords.CveCommits?
+            .Where(kv => cveIds.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        var filteredSeverityCves = CveDictionaryGenerator.GenerateSeverityCves(filteredDisclosures);
+
+        return new CveRecords(
+            LastUpdated: cveRecords.LastUpdated,
+            Title: $"CVEs affecting {releaseVersion}",
+            Disclosures: filteredDisclosures,
+            Products: filteredProducts,
+            Packages: filteredPackages,
+            Commits: filteredCommits,
+            ProductName: cveRecords.ProductName,
+            ProductCves: filteredProductCves,
+            PackageCves: filteredPackageCves,
+            ReleaseCves: new Dictionary<string, IList<string>> { [releaseVersion] = [.. cveIds] },
+            SeverityCves: filteredSeverityCves,
+            CveReleases: cveRecords.CveReleases?.Where(kv => cveIds.Contains(kv.Key))
+                .ToDictionary(kv => kv.Key, kv => kv.Value),
+            CveCommits: filteredCveCommits
+        );
+    }
+
+    /// <summary>
+    /// Validates that CVE records match what's in a release (from releases.json).
+    /// Returns a list of validation messages.
+    /// </summary>
+    public static List<string> ValidateCveData(string releaseVersion, IReadOnlyList<string>? cveIdsFromRelease, IReadOnlyList<string>? cveIdsFromCveJson)
+    {
+        var messages = new List<string>();
+        var releaseCves = cveIdsFromRelease?.ToHashSet() ?? [];
+        var cveJsonCves = cveIdsFromCveJson?.ToHashSet() ?? [];
+
+        if (releaseCves.Count == 0 && cveJsonCves.Count == 0)
+        {
+            return messages;
+        }
+
+        var inReleaseOnly = releaseCves.Except(cveJsonCves).ToList();
+        var inCveJsonOnly = cveJsonCves.Except(releaseCves).ToList();
+
+        if (inReleaseOnly.Count > 0)
+        {
+            messages.Add($"{releaseVersion}: CVE IDs in releases.json but not in cve.json: {string.Join(", ", inReleaseOnly)}");
+        }
+
+        if (inCveJsonOnly.Count > 0)
+        {
+            messages.Add($"{releaseVersion}: CVE IDs in cve.json but not in releases.json: {string.Join(", ", inCveJsonOnly)}");
+        }
+
+        return messages;
+    }
+}

--- a/src/Dotnet.Release.CveHandler/Dotnet.Release.CveHandler.csproj
+++ b/src/Dotnet.Release.CveHandler/Dotnet.Release.CveHandler.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dotnet.Release.CveHandler</PackageId>
+    <Description>CVE loading, transformation, MSRC enrichment, and dictionary generation for .NET release data</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Cve\Dotnet.Release.Cve.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Graph\Dotnet.Release.Graph.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dotnet.Release.CveHandler/MsrcClient.cs
+++ b/src/Dotnet.Release.CveHandler/MsrcClient.cs
@@ -1,0 +1,211 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Dotnet.Release.Cve;
+
+namespace Dotnet.Release.CveHandler;
+
+/// <summary>
+/// Client for fetching and parsing CVE data from Microsoft Security Response Center (MSRC) API.
+/// </summary>
+public static class MsrcClient
+{
+    /// <summary>
+    /// Fetches MSRC data for a specific security update identifier.
+    /// </summary>
+    /// <param name="msrcId">MSRC identifier (e.g., "2024-Jan")</param>
+    /// <returns>Dictionary of CVE data keyed by CVE ID, or null if fetch fails</returns>
+    public static async Task<Dictionary<string, MsrcCveData>?> FetchDataAsync(string msrcId)
+    {
+        using var httpClient = new HttpClient();
+        var url = $"https://api.msrc.microsoft.com/cvrf/v2.0/cvrf/{msrcId}";
+
+        try
+        {
+            var xmlContent = await httpClient.GetStringAsync(url);
+            return ParseXml(xmlContent);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Builds the MSRC identifier from year and month (e.g., "2024-Jan").
+    /// </summary>
+    public static string GetMsrcId(int year, int month) =>
+        $"{year}-{new DateTime(year, month, 1):MMM}";
+
+    /// <summary>
+    /// Extracts MSRC identifier from a file path containing YYYY/MM/cve.json.
+    /// </summary>
+    public static string? GetMsrcIdFromPath(string filePath)
+    {
+        var match = Regex.Match(filePath, @"(\d{4})/(\d{2})/cve\.json");
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        int year = int.Parse(match.Groups[1].Value);
+        int month = int.Parse(match.Groups[2].Value);
+        return GetMsrcId(year, month);
+    }
+
+    private static Dictionary<string, MsrcCveData> ParseXml(string xmlContent)
+    {
+        var result = new Dictionary<string, MsrcCveData>();
+
+        var tableMatch = Regex.Match(xmlContent, @"&lt;table&gt;.*?&lt;/table&gt;", RegexOptions.Singleline);
+        if (!tableMatch.Success)
+            return result;
+
+        var tableHtml = tableMatch.Value
+            .Replace("&lt;", "<")
+            .Replace("&gt;", ">")
+            .Replace("&amp;", "&");
+
+        var rowMatches = Regex.Matches(tableHtml, @"<tr>(.*?)</tr>", RegexOptions.Singleline);
+
+        foreach (Match rowMatch in rowMatches)
+        {
+            var row = rowMatch.Groups[1].Value;
+            var cells = Regex.Matches(row, @"<td>(.*?)</td>", RegexOptions.Singleline)
+                .Select(m => Regex.Replace(m.Groups[1].Value, @"<a[^>]*>(.*?)</a>", "$1").Trim())
+                .ToList();
+
+            if (cells.Count >= 4 && cells[1].StartsWith("CVE-"))
+            {
+                var cveId = cells[1];
+                var scoreText = cells[2];
+                var vector = cells[3];
+
+                if (decimal.TryParse(scoreText, out decimal score))
+                {
+                    result[cveId] = new MsrcCveData
+                    {
+                        CveId = cveId,
+                        Score = score,
+                        Vector = vector,
+                        Impact = "",
+                        Weakness = null,
+                        CnaSeverity = null
+                    };
+                }
+            }
+        }
+
+        var xdoc = XDocument.Parse(xmlContent);
+        XNamespace vulnNs = "http://www.icasi.org/CVRF/schema/vuln/1.1";
+
+        foreach (var vuln in xdoc.Descendants(vulnNs + "Vulnerability"))
+        {
+            var cveElem = vuln.Element(vulnNs + "CVE");
+            if (cveElem is null) continue;
+
+            var cveId = cveElem.Value;
+            if (!result.ContainsKey(cveId)) continue;
+
+            var impactElem = vuln.Descendants(vulnNs + "Threat")
+                .FirstOrDefault(t => t.Attribute("Type")?.Value == "Impact");
+            if (impactElem is not null)
+            {
+                var impactDesc = impactElem.Element(vulnNs + "Description")?.Value ?? "";
+                result[cveId] = result[cveId] with { Impact = impactDesc };
+            }
+
+            var severityElem = vuln.Descendants(vulnNs + "Threat")
+                .FirstOrDefault(t => t.Attribute("Type")?.Value == "Severity");
+            if (severityElem is not null)
+            {
+                var severityDesc = severityElem.Element(vulnNs + "Description")?.Value ?? "";
+                result[cveId] = result[cveId] with { CnaSeverity = severityDesc };
+            }
+
+            var cweElem = vuln.Element(vulnNs + "CWE");
+            if (cweElem is not null)
+            {
+                var cweId = cweElem.Attribute("ID")?.Value;
+                if (cweId is not null)
+                {
+                    result[cveId] = result[cveId] with { Weakness = cweId };
+                }
+            }
+
+            var acknowledgments = new List<string>();
+            var acknowledgementsElem = vuln.Element(vulnNs + "Acknowledgments");
+            if (acknowledgementsElem is not null)
+            {
+                foreach (var ackElem in acknowledgementsElem.Elements(vulnNs + "Acknowledgment"))
+                {
+                    var nameElem = ackElem.Element(vulnNs + "Name");
+                    if (nameElem is not null)
+                    {
+                        var name = Regex.Replace(nameElem.Value, @"<[^>]+>", "");
+                        name = name.Replace("&amp;", "&").Trim();
+                        if (!string.IsNullOrEmpty(name) && !acknowledgments.Contains(name))
+                        {
+                            acknowledgments.Add(name);
+                        }
+                    }
+                }
+            }
+            if (acknowledgments.Count > 0)
+            {
+                result[cveId] = result[cveId] with { Acknowledgments = acknowledgments };
+            }
+
+            var faqs = new List<CnaFaq>();
+            var notesElems = vuln.Elements(vulnNs + "Notes");
+            foreach (var notesElem in notesElems)
+            {
+                var faqNotes = notesElem.Elements(vulnNs + "Note")
+                    .Where(n => n.Attribute("Type")?.Value == "FAQ");
+
+                foreach (var faqNote in faqNotes)
+                {
+                    var htmlContent = faqNote.Value;
+                    var questionMatch = Regex.Match(htmlContent, @"<strong>(.*?)</strong>", RegexOptions.Singleline);
+                    var answerMatch = Regex.Match(htmlContent, @"</strong>\s*</p>\s*<p>(.*?)</p>", RegexOptions.Singleline);
+
+                    if (questionMatch.Success)
+                    {
+                        var question = Regex.Replace(questionMatch.Groups[1].Value, @"<[^>]+>", "").Trim();
+                        question = question.Replace("&amp;", "&");
+
+                        var answer = answerMatch.Success
+                            ? Regex.Replace(answerMatch.Groups[1].Value, @"<[^>]+>", "").Trim()
+                            : "";
+                        answer = answer.Replace("&amp;", "&");
+
+                        if (!string.IsNullOrEmpty(question) && !string.IsNullOrEmpty(answer))
+                        {
+                            faqs.Add(new CnaFaq(question, answer));
+                        }
+                    }
+                }
+            }
+            if (faqs.Count > 0)
+            {
+                result[cveId] = result[cveId] with { Faqs = faqs };
+            }
+        }
+
+        return result;
+    }
+}
+
+/// <summary>
+/// CVE metadata from Microsoft Security Response Center.
+/// </summary>
+public record MsrcCveData
+{
+    required public string CveId { get; init; }
+    required public decimal Score { get; init; }
+    required public string Vector { get; init; }
+    required public string Impact { get; init; }
+    public string? Weakness { get; init; }
+    public string? CnaSeverity { get; init; }
+    public List<string>? Acknowledgments { get; init; }
+    public List<CnaFaq>? Faqs { get; init; }
+}

--- a/src/Dotnet.Release.CveHandler/ProductNameHelper.cs
+++ b/src/Dotnet.Release.CveHandler/ProductNameHelper.cs
@@ -1,0 +1,18 @@
+namespace Dotnet.Release.CveHandler;
+
+/// <summary>
+/// Helper for standardizing product display names.
+/// </summary>
+public static class ProductNameHelper
+{
+    public static string GetDisplayName(string productName) => productName switch
+    {
+        "dotnet-runtime-libraries" => ".NET Runtime Libraries",
+        "dotnet-runtime-aspnetcore" => "ASP.NET Core Runtime",
+        "dotnet-runtime" => ".NET Runtime Libraries",
+        "dotnet-aspnetcore" => "ASP.NET Core Runtime",
+        "dotnet-sdk" => ".NET SDK",
+        "aspnetcore-runtime" => "ASP.NET Core Runtime",
+        _ => productName
+    };
+}


### PR DESCRIPTION
## Summary

Adds two new projects for CVE disclosure management, pulled from distroessed and adapted to dotnet-release conventions.

### New: `Dotnet.Release.CveHandler` (library)

CVE loading, transformation, MSRC enrichment, and dictionary generation:

- **CveLoader** — loads/finds cve.json files from paths or timeline directories
- **CveTransformer** — converts to HAL summaries, filters by release, cross-validates against releases.json
- **CveDictionaryGenerator** — generates all lookup tables (product_cves, release_cves, severity_cves, etc.)
- **MsrcClient** — fetches CVSS scores, CWE, severity, acknowledgments from MSRC CVRF API
- **ProductNameHelper** — standardizes product display names

### New: `Dotnet.Release.CveEnricher` (tool)

Agentic CLI with three subcommands:

| Command | Purpose |
|---------|---------|
| `synthesize` | Generate cve.json from releases.json + MSRC data |
| `validate` | Validate existing cve.json (taxonomy, versions, FKs, dictionaries, URLs, MSRC) |
| `update` | Update lookup dictionaries + fetch fresh CVSS/CNA data |

**Agentic design:**
- `--json` on all subcommands — emits structured JSON to stdout for agent consumption
- `--month YYYY-MM` for fine-grained single-month operations
- `--all` for batch processing
- Progress/diagnostics → stderr, data → stdout
- Exit codes: 0 = success, 1 = validation errors, 2 = runtime error
- `PackAsTool` + `PublishAot` (same packaging pattern as Dotnet.Release.Tools)

### Smoke tested

Validated 18 real cve.json files from the dotnet/core release-index branch:
- 16 passed all checks
- 2 flagged real data integrity issues (commits data)

Full solution builds clean with zero warnings. All 24 existing tests pass.