### PR TITLE
Add CveEnricher to CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,18 +113,26 @@ jobs:
         run: rm -rf artifacts/package
 
       - name: Pack pointer package
-        run: dotnet pack src/Dotnet.Release.Tools -c Release -p:OfficialBuild=true
+        run: |
+          dotnet pack src/Dotnet.Release.Tools -c Release -p:OfficialBuild=true
+          dotnet pack src/Dotnet.Release.CveEnricher -c Release -p:OfficialBuild=true
 
       - name: Pack non-AOT (any) package
-        run: dotnet pack src/Dotnet.Release.Tools -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
+        run: |
+          dotnet pack src/Dotnet.Release.Tools -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
+          dotnet pack src/Dotnet.Release.CveEnricher -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
 
       - name: Pack linux-x64 AOT package
-        run: dotnet pack src/Dotnet.Release.Tools -c Release -r linux-x64 -p:OfficialAotBuild=true
+        run: |
+          dotnet pack src/Dotnet.Release.Tools -c Release -r linux-x64 -p:OfficialAotBuild=true
+          dotnet pack src/Dotnet.Release.CveEnricher -c Release -r linux-x64 -p:OfficialAotBuild=true
 
       - name: Smoke test
         run: |
           dotnet tool install -g Dotnet.Release.Tools --add-source artifacts/package/release --prerelease
           dotnet-release --help || true
+          dotnet tool install -g Dotnet.Release.CveEnricher --add-source artifacts/package/release --prerelease
+          dotnet-cve-enricher || true
 
       - name: Upload packages
         uses: actions/upload-artifact@v4
@@ -164,7 +172,9 @@ jobs:
         run: dotnet nuget update source github-richlander --username richlander --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --configfile nuget.config
 
       - name: Pack RID-specific package
-        run: dotnet pack src/Dotnet.Release.Tools -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
+        run: |
+          dotnet pack src/Dotnet.Release.Tools -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
+          dotnet pack src/Dotnet.Release.CveEnricher -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
 
       - name: Upload RID package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,9 @@ on:
 
 env:
   NUGET_SOURCE: https://nuget.pkg.github.com/richlander/index.json
-  TOOL_PROJECT: src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+  TOOL_PROJECTS: >-
+    src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+    src/Dotnet.Release.CveEnricher/Dotnet.Release.CveEnricher.csproj
 
 jobs:
   # Pack library packages + tool pointer package
@@ -58,7 +60,10 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Pack AOT (${{ matrix.rid }})
-        run: dotnet pack ${{ env.TOOL_PROJECT }} -c Release -r ${{ matrix.rid }} -o ./nupkg
+        run: |
+          for proj in ${{ env.TOOL_PROJECTS }}; do
+            dotnet pack "$proj" -c Release -r ${{ matrix.rid }} -o ./nupkg
+          done
 
       - uses: actions/upload-artifact@v4
         with:
@@ -77,7 +82,10 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Pack CoreCLR fallback
-        run: dotnet pack ${{ env.TOOL_PROJECT }} -c Release -r any -p:PublishAot=false -o ./nupkg
+        run: |
+          for proj in ${{ env.TOOL_PROJECTS }}; do
+            dotnet pack "$proj" -c Release -r any -p:PublishAot=false -o ./nupkg
+          done
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Updates both workflows to build, pack, and publish AOT tool packages for `Dotnet.Release.CveEnricher` alongside `Dotnet.Release.Tools`.

**CI (`ci.yml`):**
- Packs pointer, non-AOT, and linux-x64 AOT packages for both tools
- Smoke tests both tools after packing
- RID matrix builds both tools per platform

**Publish (`publish.yml`):**
- `TOOL_PROJECTS` env var lists both tool csproj paths
- AOT and CoreCLR fallback steps loop over both projects
- All RID-specific packages for both tools are published to GitHub Packages