### PR TITLE
Fix publish workflow: add shell: bash for Windows runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Pack AOT (${{ matrix.rid }})
+        shell: bash
         run: |
           for proj in ${{ env.TOOL_PROJECTS }}; do
             dotnet pack "$proj" -c Release -r ${{ matrix.rid }} -o ./nupkg


### PR DESCRIPTION
The `for/in/do` loop in `pack-tool-rid` fails on `windows-latest` because the default shell is PowerShell. Adds `shell: bash` to the AOT pack step.