### PR TITLE
Add releases-index, releases.md, and verify releases tools

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -24,6 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Release.Graph\Dotnet.Release.Graph.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Releases\Dotnet.Release.Releases.csproj" />
     <ProjectReference Include="..\Dotnet.Release.Support\Dotnet.Release.Support.csproj" />
     <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
     <PackageReference Include="Markout" Version="0.10.2" />
@@ -36,6 +38,7 @@
     <EmbeddedResource Include="os-packages-template.md" />
     <EmbeddedResource Include="dotnet-dependencies-template.md" />
     <EmbeddedResource Include="dotnet-packages-template.md" />
+    <EmbeddedResource Include="releases-template.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Dotnet.Release;
+using Dotnet.Release.Releases;
 using Dotnet.Release.Support;
 using Dotnet.Release.Tools;
 
@@ -52,12 +53,41 @@ if (args.Length > 2 && args[2] == "--export-template")
         case "dotnet-packages":
             DotnetPackagesGenerator.ExportTemplate(Console.Out);
             break;
+        case "releases":
+            ReleasesGenerator.ExportTemplate(Console.Out);
+            break;
         default:
             Console.Error.WriteLine($"Unknown type: {type}");
             PrintUsage();
             return 1;
     }
     return 0;
+}
+
+// Types that don't require a version number
+if (type is "releases-index" or "releases")
+{
+    string genPath = ".";
+    string? genTemplatePath = null;
+
+    for (int i = 2; i < args.Length; i++)
+    {
+        if (args[i] == "--template" && i + 1 < args.Length)
+        {
+            genTemplatePath = args[++i];
+        }
+        else if (!args[i].StartsWith('-'))
+        {
+            genPath = args[i];
+        }
+    }
+
+    return type switch
+    {
+        "releases-index" => await GenerateReleasesIndexAsync(genPath),
+        "releases" => await GenerateReleasesAsync(genPath, genTemplatePath),
+        _ => 1
+    };
 }
 
 if (args.Length < 3 || !decimal.TryParse(args[2], out _))
@@ -280,14 +310,73 @@ async Task<int> GenerateDotnetPackagesAsync(IAdaptivePath path, string version, 
     return 0;
 }
 
+async Task<int> GenerateReleasesIndexAsync(string basePath)
+{
+    Console.Error.WriteLine($"Generating {FileNames.ReleasesIndex} from {Path.GetFullPath(basePath)}...");
+
+    string outputPath = Path.Combine(basePath, FileNames.ReleasesIndex);
+    using var fileStream = File.Create(outputPath);
+
+    await ReleasesIndexGenerator.GenerateAsync(basePath, fileStream, Console.Error);
+
+    // Add trailing newline
+    fileStream.WriteByte((byte)'\n');
+
+    var info = new FileInfo(outputPath);
+    Console.Error.WriteLine($"Generated {info.Length} bytes");
+    Console.Error.WriteLine(info.FullName);
+    return 0;
+}
+
+async Task<int> GenerateReleasesAsync(string basePath, string? templatePath)
+{
+    Console.Error.WriteLine($"Generating releases.md from {Path.GetFullPath(basePath)}...");
+
+    string outputPath = Path.Combine(basePath, "releases.md");
+    await using (var output = new StreamWriter(File.Open(outputPath, FileMode.Create)))
+    {
+        await ReleasesGenerator.GenerateAsync(basePath, output, Console.Error, templatePath);
+    }
+
+    var info = new FileInfo(outputPath);
+    Console.Error.WriteLine($"Generated {info.Length} bytes");
+    Console.Error.WriteLine(info.FullName);
+    return 0;
+}
+
+async Task<int> VerifyReleasesAsync(string basePath, string? version, bool skipHash)
+{
+    string scope = version is not null ? $".NET {version}" : "all supported versions";
+    Console.Error.WriteLine($"Verifying release links for {scope} in {Path.GetFullPath(basePath)}...");
+
+    using var client = new HttpClient();
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("dotnet-release-verifier/1.0");
+    client.Timeout = TimeSpan.FromMinutes(5);
+
+    var report = await ReleasesVerifier.VerifyAsync(basePath, client, Console.Error, skipHash, version);
+
+    if (!report.HasIssues)
+    {
+        Console.Error.WriteLine("No issues found.");
+        return 0;
+    }
+
+    var ctx = new ReleasesVerificationReportContext();
+    ctx.Serialize(report, Console.Out);
+    return 2;
+}
+
 static void PrintUsage()
 {
     Console.Error.WriteLine("Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]");
+    Console.Error.WriteLine("       dotnet-release generate releases-index [path]");
+    Console.Error.WriteLine("       dotnet-release generate releases [path] [--template <file>]");
     Console.Error.WriteLine("       dotnet-release generate <type> --export-template");
     Console.Error.WriteLine("       dotnet-release verify <type> <version> [path-or-url]");
+    Console.Error.WriteLine("       dotnet-release verify releases [version] [path] [--skip-hash]");
     Console.Error.WriteLine("       dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]");
     Console.Error.WriteLine();
-    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies");
+    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, releases-index, releases");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0");
@@ -296,10 +385,17 @@ static void PrintUsage()
     Console.Error.WriteLine("  dotnet-release generate dotnet-dependencies 11.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate os-packages --export-template > my-template.md");
+    Console.Error.WriteLine("  dotnet-release generate releases-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release generate releases ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release generate releases --export-template > my-template.md");
     Console.Error.WriteLine("  dotnet-release verify supported-os 10.0");
     Console.Error.WriteLine("  dotnet-release verify supported-os 10.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release verify os-packages 10.0");
     Console.Error.WriteLine("  dotnet-release verify os-packages 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release verify releases ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release verify releases 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release verify releases 10.0.5 ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release verify releases ~/git/core/release-notes --skip-hash");
     Console.Error.WriteLine("  dotnet-release query distro-packages --dotnet-version 9.0");
     Console.Error.WriteLine("  dotnet-release query distro-packages --dotnet-version 9.0 --output distro-packages.json");
     Console.Error.WriteLine();
@@ -317,11 +413,50 @@ async Task<int> HandleVerifyAsync(string[] args)
 
     string verifyType = args[1];
 
-    if (verifyType is not "supported-os" and not "os-packages")
+    if (verifyType is not "supported-os" and not "os-packages" and not "releases")
     {
         Console.Error.WriteLine($"Unknown verify type: {verifyType}");
         PrintUsage();
         return 1;
+    }
+
+    // "verify releases" accepts an optional version filter
+    if (verifyType == "releases")
+    {
+        string verifyPath = ".";
+        string? verifyVersion = null;
+        bool skipHash = false;
+
+        for (int i = 2; i < args.Length; i++)
+        {
+            if (args[i] == "--skip-hash")
+            {
+                skipHash = true;
+            }
+            else if (!args[i].StartsWith('-'))
+            {
+                // Distinguish version from path: versions contain only digits and dots
+                if (verifyVersion is null && args[i].Length > 0 && char.IsDigit(args[i][0]) && args[i].All(c => char.IsDigit(c) || c == '.' || c == '-' || char.IsLetter(c)))
+                {
+                    // Could be a version like "10.0" or "10.0.5" or a path like "/tmp"
+                    // Treat as version if it matches a version-like pattern (starts with digit.digit)
+                    if (args[i].Contains('.') && char.IsDigit(args[i][0]) && !Path.IsPathRooted(args[i]) && !args[i].Contains(Path.DirectorySeparatorChar))
+                    {
+                        verifyVersion = args[i];
+                    }
+                    else
+                    {
+                        verifyPath = args[i];
+                    }
+                }
+                else
+                {
+                    verifyPath = args[i];
+                }
+            }
+        }
+
+        return await VerifyReleasesAsync(verifyPath, verifyVersion, skipHash);
     }
 
     if (!decimal.TryParse(args[2], out _))

--- a/src/Dotnet.Release.Tools/ReleasesGenerator.cs
+++ b/src/Dotnet.Release.Tools/ReleasesGenerator.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Releases;
+using Markout;
+using Markout.Templates;
+using MarkdownTable.Formatting;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates releases.md from per-major-version releases.json files using a Markout template.
+/// </summary>
+public static class ReleasesGenerator
+{
+    private const string EmbeddedTemplateName = "Dotnet.Release.Tools.releases-template.md";
+
+    public static MarkoutTemplate LoadTemplate(string? templatePath = null)
+    {
+        if (templatePath is not null)
+            return MarkoutTemplate.Load(templatePath);
+
+        var stream = typeof(ReleasesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+
+        return MarkoutTemplate.Load(stream);
+    }
+
+    public static void ExportTemplate(TextWriter output)
+    {
+        using var stream = typeof(ReleasesGenerator).Assembly.GetManifestResourceStream(EmbeddedTemplateName)
+            ?? throw new InvalidOperationException($"Embedded template not found: {EmbeddedTemplateName}");
+        using var reader = new StreamReader(stream);
+        output.Write(reader.ReadToEnd());
+    }
+
+    public static async Task GenerateAsync(string releasesNotesPath, TextWriter output, TextWriter log, string? templatePath = null)
+    {
+        var versions = ReleasesIndexGenerator.DiscoverVersions(releasesNotesPath);
+        var releases = new List<ReleaseInfo>();
+
+        foreach (var version in versions)
+        {
+            var releasesPath = Path.Combine(releasesNotesPath, version, FileNames.Releases);
+            if (!File.Exists(releasesPath)) continue;
+
+            log.WriteLine($"  Reading {version}/{FileNames.Releases}...");
+            using var stream = File.OpenRead(releasesPath);
+            var overview = await JsonSerializer.DeserializeAsync(stream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
+            if (overview is null) continue;
+
+            releases.Add(new ReleaseInfo(version, overview));
+        }
+
+        var supported = releases.Where(r => r.Overview.SupportPhase != SupportPhase.Eol).ToList();
+        var eol = releases.Where(r => r.Overview.SupportPhase == SupportPhase.Eol).ToList();
+
+        var template = LoadTemplate(templatePath);
+        template.TableOptions = new TableFormatterOptions { AutoTune = true };
+
+        template.Bind("supported", new SupportedReleasesBinding(supported));
+
+        if (eol.Count > 0)
+        {
+            template.Bind("eol", new EolReleasesBinding(eol));
+        }
+
+        template.SkipUnboundPlaceholders = true;
+
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new() { AutoTune = true }
+        };
+
+        output.WriteLine(template.Render(options));
+    }
+
+    internal record ReleaseInfo(string Version, MajorReleaseOverview Overview);
+
+    /// <summary>
+    /// Renders the supported releases table with columns:
+    /// Version | Release Date | Release type | Support phase | Latest Patch Version | End of Support
+    /// </summary>
+    private class SupportedReleasesBinding(List<ReleaseInfo> releases) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            List<string> linkDefs = [];
+
+            writer.WriteTableStart("Version", "Release Date", "Release type", "Support phase", "Latest Patch Version", "End of Support");
+
+            foreach (var info in releases)
+            {
+                var overview = info.Overview;
+                var latestPatch = overview.Releases.FirstOrDefault();
+                string product = ReleasesIndexGenerator.InferProduct(info.Version);
+                string displayVersion = $"{product} {overview.ChannelVersion}";
+                string versionCell = $"[{displayVersion}](./{overview.ChannelVersion}/README.md)";
+
+                string gaDate = GetGaDate(overview);
+
+                string releaseType = $"[{overview.ReleaseType.ToString().ToUpperInvariant()}][policies]";
+                string supportPhase = FormatSupportPhase(overview.SupportPhase);
+                string patchVersion = overview.LatestRelease;
+
+                string patchLink = latestPatch is not null
+                    ? GetPatchNotesPath(latestPatch, overview.ChannelVersion)
+                    : $"./{overview.ChannelVersion}/{patchVersion}/{patchVersion}.md";
+
+                linkDefs.Add($"[{patchVersion}]: {patchLink}");
+                string patchCell = $"[{patchVersion}][{patchVersion}]";
+
+                string eolDate = overview.EolDate != DateOnly.MinValue
+                    ? FormatDate(overview.EolDate)
+                    : "TBD";
+
+                writer.WriteTableRow(versionCell, gaDate, releaseType, supportPhase, patchCell, eolDate);
+            }
+
+            writer.WriteTableEnd();
+            writer.WriteLinkDefinitions(linkDefs.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Renders the end-of-life releases table with columns:
+    /// Version | Release Date | Support | Final Patch Version | End of Support
+    /// </summary>
+    private class EolReleasesBinding(List<ReleaseInfo> releases) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            List<string> linkDefs = [];
+
+            writer.WriteTableStart("Version", "Release Date", "Support", "Final Patch Version", "End of Support");
+
+            foreach (var info in releases)
+            {
+                var overview = info.Overview;
+                var latestPatch = overview.Releases.FirstOrDefault();
+                string product = ReleasesIndexGenerator.InferProduct(info.Version);
+                string displayVersion = $"{product} {overview.ChannelVersion}";
+                string versionCell = $"[{displayVersion}](./{overview.ChannelVersion}/README.md)";
+
+                string gaDate = GetGaDate(overview);
+
+                string releaseType = $"[{overview.ReleaseType.ToString().ToUpperInvariant()}][policies]";
+                string patchVersion = overview.LatestRelease;
+
+                string patchLink = latestPatch is not null
+                    ? GetPatchNotesPath(latestPatch, overview.ChannelVersion)
+                    : $"./{overview.ChannelVersion}/{patchVersion}/{patchVersion}.md";
+
+                linkDefs.Add($"[{patchVersion}]: {patchLink}");
+                string patchCell = $"[{patchVersion}][{patchVersion}]";
+
+                string eolDate = overview.EolDate != DateOnly.MinValue
+                    ? FormatDate(overview.EolDate)
+                    : "-";
+
+                writer.WriteTableRow(versionCell, gaDate, releaseType, patchCell, eolDate);
+            }
+
+            writer.WriteTableEnd();
+            writer.WriteLinkDefinitions(linkDefs.ToArray());
+        }
+    }
+
+    static string GetGaDate(MajorReleaseOverview overview)
+    {
+        if (overview.Releases.Count == 0) return "-";
+
+        // Find the GA release (e.g., "10.0.0" — no preview/rc suffix)
+        var gaRelease = overview.Releases.FirstOrDefault(r =>
+            !r.ReleaseVersion.Contains("preview", StringComparison.OrdinalIgnoreCase) &&
+            !r.ReleaseVersion.Contains("rc", StringComparison.OrdinalIgnoreCase) &&
+            r.ReleaseVersion.EndsWith(".0"));
+
+        if (gaRelease is not null)
+        {
+            return FormatDate(gaRelease.ReleaseDate);
+        }
+
+        // Fallback: earliest release date
+        return FormatDate(overview.Releases[^1].ReleaseDate);
+    }
+
+    static string GetPatchNotesPath(PatchRelease release, string channelVersion)
+    {
+        const string marker = "release-notes/";
+        int idx = release.ReleaseNotes.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+        {
+            return "./" + release.ReleaseNotes[(idx + marker.Length)..];
+        }
+
+        return $"./{channelVersion}/{release.ReleaseVersion}/{release.ReleaseVersion}.md";
+    }
+
+    static string FormatDate(DateOnly date) => date.ToString("MMMM d, yyyy");
+
+    static string FormatSupportPhase(SupportPhase phase) => phase switch
+    {
+        SupportPhase.Preview => "Preview",
+        SupportPhase.GoLive => "Go Live",
+        SupportPhase.Active => "Active",
+        SupportPhase.Maintenance => "Maintenance",
+        SupportPhase.Eol => "End of life",
+        _ => phase.ToString()
+    };
+}

--- a/src/Dotnet.Release.Tools/ReleasesIndexGenerator.cs
+++ b/src/Dotnet.Release.Tools/ReleasesIndexGenerator.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Releases;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Generates releases-index.json from per-major-version releases.json files.
+/// </summary>
+public static class ReleasesIndexGenerator
+{
+    private const string CdnBaseUrl = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/";
+
+    public static async Task GenerateAsync(string releasesNotesPath, Stream output, TextWriter log)
+    {
+        var versions = DiscoverVersions(releasesNotesPath);
+        log.WriteLine($"Found {versions.Count} versions: {string.Join(", ", versions)}");
+
+        using var writer = new Utf8JsonWriter(output, new JsonWriterOptions { Indented = true });
+        writer.WriteStartObject();
+        writer.WritePropertyName("releases-index");
+        writer.WriteStartArray();
+
+        foreach (var version in versions)
+        {
+            var releasesPath = Path.Combine(releasesNotesPath, version, FileNames.Releases);
+            if (!File.Exists(releasesPath))
+            {
+                log.WriteLine($"  Skipping {version}: no {FileNames.Releases}");
+                continue;
+            }
+
+            log.WriteLine($"  Reading {version}/{FileNames.Releases}...");
+            using var stream = File.OpenRead(releasesPath);
+            var overview = await JsonSerializer.DeserializeAsync(stream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
+
+            if (overview is null)
+            {
+                log.WriteLine($"  Skipping {version}: failed to deserialize");
+                continue;
+            }
+
+            WriteIndexItem(writer, version, overview, releasesNotesPath);
+        }
+
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        await writer.FlushAsync();
+    }
+
+    /// <summary>
+    /// Discovers version directories (e.g. "10.0", "9.0") by scanning for directories
+    /// whose names parse as decimals, ordered newest-first.
+    /// </summary>
+    internal static List<string> DiscoverVersions(string basePath)
+    {
+        return Directory.GetDirectories(basePath)
+            .Select(Path.GetFileName)
+            .Where(name => name is not null && decimal.TryParse(name, out _))
+            .OrderByDescending(name => decimal.Parse(name!))
+            .Select(name => name!)
+            .ToList();
+    }
+
+    static void WriteIndexItem(Utf8JsonWriter writer, string version, MajorReleaseOverview overview, string basePath)
+    {
+        var latestPatch = overview.Releases.FirstOrDefault();
+
+        writer.WriteStartObject();
+        writer.WriteString("channel-version", overview.ChannelVersion);
+        writer.WriteString("latest-release", overview.LatestRelease);
+        writer.WriteString("latest-release-date", overview.LatestReleaseDate.ToString("yyyy-MM-dd"));
+        writer.WriteBoolean("security", latestPatch?.Security ?? false);
+        writer.WriteString("latest-runtime", overview.LatestRuntime);
+        writer.WriteString("latest-sdk", overview.LatestSdk);
+        writer.WriteString("product", InferProduct(version));
+        writer.WriteString("support-phase", FormatSupportPhase(overview.SupportPhase));
+
+        if (overview.EolDate != DateOnly.MinValue)
+        {
+            writer.WriteString("eol-date", overview.EolDate.ToString("yyyy-MM-dd"));
+        }
+
+        writer.WriteString("release-type", FormatReleaseType(overview.ReleaseType));
+        writer.WriteString("releases.json", $"{CdnBaseUrl}{version}/{FileNames.Releases}");
+
+        var supportedOsPath = Path.Combine(basePath, version, FileNames.SupportedOs);
+        if (File.Exists(supportedOsPath))
+        {
+            writer.WriteString("supported-os.json", $"{CdnBaseUrl}{version}/{FileNames.SupportedOs}");
+        }
+
+        writer.WriteEndObject();
+    }
+
+    internal static string InferProduct(string version)
+    {
+        if (decimal.TryParse(version, out var v) && v >= 5.0m) return ".NET";
+        return ".NET Core";
+    }
+
+    internal static string FormatSupportPhase(SupportPhase phase) => phase switch
+    {
+        SupportPhase.Preview => "preview",
+        SupportPhase.GoLive => "go-live",
+        SupportPhase.Active => "active",
+        SupportPhase.Maintenance => "maintenance",
+        SupportPhase.Eol => "eol",
+        _ => phase.ToString().ToLowerInvariant()
+    };
+
+    internal static string FormatReleaseType(ReleaseType type) => type switch
+    {
+        ReleaseType.LTS => "lts",
+        ReleaseType.STS => "sts",
+        _ => type.ToString().ToLowerInvariant()
+    };
+}

--- a/src/Dotnet.Release.Tools/ReleasesVerifier.cs
+++ b/src/Dotnet.Release.Tools/ReleasesVerifier.cs
@@ -1,0 +1,625 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Releases;
+using Markout;
+
+namespace Dotnet.Release.Tools;
+
+/// <summary>
+/// Verifies that all URLs in the latest patch release of each supported .NET version
+/// return HTTP 200, and optionally validates file hashes.
+/// </summary>
+public static class ReleasesVerifier
+{
+    public static async Task<ReleasesVerificationReport> VerifyAsync(
+        string releasesNotesPath, HttpClient client, TextWriter log, bool skipHash = false, string? filterVersion = null)
+    {
+        // Parse filter: "10.0" → channel only, "10.0.5" → specific patch
+        string? filterChannel = null;
+        string? filterPatch = null;
+
+        if (filterVersion is not null)
+        {
+            // Channel version has one dot (e.g., "10.0"), patch has two+ (e.g., "10.0.5")
+            int dotCount = filterVersion.Count(c => c == '.');
+            if (dotCount == 1)
+            {
+                filterChannel = filterVersion;
+            }
+            else
+            {
+                // Extract channel from patch: "10.0.5" → "10.0"
+                int secondDot = filterVersion.IndexOf('.', filterVersion.IndexOf('.') + 1);
+                filterChannel = filterVersion[..secondDot];
+                filterPatch = filterVersion;
+            }
+        }
+
+        var versions = ReleasesIndexGenerator.DiscoverVersions(releasesNotesPath);
+        var versionReports = new List<MajorVersionLinkReport>();
+
+        foreach (var version in versions)
+        {
+            // Filter to specific channel version if requested
+            if (filterChannel is not null && version != filterChannel) continue;
+
+            var releasesPath = Path.Combine(releasesNotesPath, version, FileNames.Releases);
+            if (!File.Exists(releasesPath)) continue;
+
+            using var stream = File.OpenRead(releasesPath);
+            var overview = await JsonSerializer.DeserializeAsync(stream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
+            if (overview is null) continue;
+
+            // Skip EOL versions unless a specific version was requested
+            if (filterVersion is null && overview.SupportPhase == SupportPhase.Eol) continue;
+
+            PatchRelease? targetPatch;
+            string targetVersion;
+
+            if (filterPatch is not null)
+            {
+                // Find the specific patch release
+                targetPatch = overview.Releases.FirstOrDefault(r => r.ReleaseVersion == filterPatch);
+                if (targetPatch is null)
+                {
+                    log.WriteLine($"Patch release {filterPatch} not found in {version}/releases.json");
+                    return new ReleasesVerificationReport
+                    {
+                        GeneratedAt = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm UTC"),
+                        VersionsChecked = "none",
+                        Versions = []
+                    };
+                }
+                targetVersion = filterPatch;
+            }
+            else
+            {
+                targetPatch = overview.Releases.FirstOrDefault();
+                if (targetPatch is null) continue;
+                targetVersion = overview.LatestRelease;
+            }
+
+            log.WriteLine($"Checking .NET {version} ({targetVersion})...");
+            var report = await VerifyPatchReleaseAsync(version, targetVersion, overview, targetPatch, releasesNotesPath, client, log, skipHash);
+            versionReports.Add(report);
+        }
+
+        return new ReleasesVerificationReport
+        {
+            GeneratedAt = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm UTC"),
+            VersionsChecked = string.Join(", ", versionReports.Select(v => $".NET {v.Version}")),
+            Versions = versionReports
+        };
+    }
+
+    static async Task<MajorVersionLinkReport> VerifyPatchReleaseAsync(
+        string version, string patchVersion, MajorReleaseOverview overview, PatchRelease release,
+        string releasesNotesPath, HttpClient client, TextWriter log, bool skipHash)
+    {
+        var urls = CollectUrls(release);
+        log.WriteLine($"  {urls.Count} URLs to check");
+
+        // HTTP HEAD checks with concurrency limit
+        var brokenLinks = new List<LinkIssue>();
+        var semaphore = new SemaphoreSlim(16);
+
+        var httpTasks = urls.Select(async u =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                return await CheckUrlAsync(u, client);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        var httpResults = await Task.WhenAll(httpTasks);
+
+        foreach (var result in httpResults)
+        {
+            if (!result.IsSuccess)
+            {
+                brokenLinks.Add(new LinkIssue(result.Url.Component, result.Url.FileName, result.Url.Url, result.StatusDescription));
+                log.WriteLine($"  ❌ {result.Url.Component}/{result.Url.FileName}: {result.StatusDescription}");
+            }
+        }
+
+        int successCount = httpResults.Count(r => r.IsSuccess);
+        log.WriteLine($"  {successCount}/{urls.Count} URLs returned 200");
+
+        // Hash verification for binary files
+        var hashMismatches = new List<LinkIssue>();
+
+        if (!skipHash)
+        {
+            var filesWithHashes = urls
+                .Where(u => !string.IsNullOrEmpty(u.Hash))
+                .Where(u => httpResults.First(r => r.Url == u).IsSuccess) // only check files that returned 200
+                .ToList();
+
+            if (filesWithHashes.Count > 0)
+            {
+                log.WriteLine($"  Verifying {filesWithHashes.Count} file hashes...");
+                var hashSemaphore = new SemaphoreSlim(4);
+
+                var hashTasks = filesWithHashes.Select(async u =>
+                {
+                    await hashSemaphore.WaitAsync();
+                    try
+                    {
+                        return await VerifyHashAsync(u, client, log);
+                    }
+                    finally
+                    {
+                        hashSemaphore.Release();
+                    }
+                });
+
+                var hashResults = await Task.WhenAll(hashTasks);
+
+                foreach (var result in hashResults)
+                {
+                    if (!result.IsMatch)
+                    {
+                        string detail = result.ActualHash.StartsWith("Error:")
+                            ? result.ActualHash
+                            : $"Hash mismatch: expected {Truncate(result.ExpectedHash)}..., got {Truncate(result.ActualHash)}...";
+
+                        hashMismatches.Add(new LinkIssue(result.Url.Component, result.Url.FileName, result.Url.Url, detail));
+                        log.WriteLine($"  ❌ Hash mismatch: {result.Url.FileName}");
+                    }
+                }
+
+                int hashSuccessCount = hashResults.Count(r => r.IsMatch);
+                log.WriteLine($"  {hashSuccessCount}/{filesWithHashes.Count} hashes verified");
+            }
+        }
+
+        // Verify latest.version files on CDN match releases.json
+        log.WriteLine($"  Checking latest.version files on CDN...");
+        var versionMismatches = await VerifyLatestVersionFilesAsync(version, overview, client, log);
+
+        // Verify aka.ms redirect targets match releases.json URLs
+        var akamsLinks = CollectAkamsLinks(release, version, releasesNotesPath, log);
+        var akamsMismatches = await VerifyAkamsLinksAsync(akamsLinks, log);
+
+        // Build report
+        var issues = new List<LinkIssueBucket>();
+
+        if (brokenLinks.Count > 0)
+        {
+            issues.Add(new LinkIssueBucket
+            {
+                Alert = new Callout(CalloutSeverity.Warning, "Broken links (non-200 response)"),
+                Items = brokenLinks
+            });
+        }
+
+        if (hashMismatches.Count > 0)
+        {
+            issues.Add(new LinkIssueBucket
+            {
+                Alert = new Callout(CalloutSeverity.Warning, "Hash mismatches"),
+                Items = hashMismatches
+            });
+        }
+
+        if (versionMismatches.Count > 0)
+        {
+            issues.Add(new LinkIssueBucket
+            {
+                Alert = new Callout(CalloutSeverity.Important, "CDN latest.version files do not match releases.json"),
+                Items = versionMismatches
+            });
+        }
+
+        if (akamsMismatches.Count > 0)
+        {
+            issues.Add(new LinkIssueBucket
+            {
+                Alert = new Callout(CalloutSeverity.Warning, "aka.ms redirect mismatches"),
+                Items = akamsMismatches
+            });
+        }
+
+        return new MajorVersionLinkReport
+        {
+            Version = version,
+            PatchVersion = patchVersion,
+            UrlsChecked = urls.Count,
+            Issues = issues
+        };
+    }
+
+    static List<UrlInfo> CollectUrls(PatchRelease release)
+    {
+        var urls = new List<UrlInfo>();
+
+        if (!string.IsNullOrEmpty(release.ReleaseNotes))
+        {
+            urls.Add(new UrlInfo("Release Notes", "release-notes", release.ReleaseNotes, null));
+        }
+
+        foreach (var cve in release.CveList)
+        {
+            if (!string.IsNullOrEmpty(cve.CveUrl))
+            {
+                urls.Add(new UrlInfo("CVE", cve.CveId, cve.CveUrl, null));
+            }
+        }
+
+        AddComponentFiles(urls, "Runtime", release.Runtime.Files);
+        AddComponentFiles(urls, "SDK", release.Sdk.Files);
+        AddComponentFiles(urls, "ASP.NET Core", release.AspnetcoreRuntime.Files);
+
+        if (release.WindowsDesktop is not null)
+        {
+            AddComponentFiles(urls, "Windows Desktop", release.WindowsDesktop.Files);
+        }
+
+        if (release.Symbols is not null)
+        {
+            AddComponentFiles(urls, "Symbols", release.Symbols.Files);
+        }
+
+        return urls;
+    }
+
+    static void AddComponentFiles(List<UrlInfo> urls, string component, IList<ComponentFile> files)
+    {
+        foreach (var file in files)
+        {
+            urls.Add(new UrlInfo(component, file.Name, file.Url, file.Hash));
+        }
+    }
+
+    static async Task<HttpCheckResult> CheckUrlAsync(UrlInfo url, HttpClient client)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, url.Url);
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new HttpCheckResult(url, true, $"{(int)response.StatusCode}");
+            }
+
+            return new HttpCheckResult(url, false, $"{(int)response.StatusCode} {response.ReasonPhrase}");
+        }
+        catch (Exception ex)
+        {
+            return new HttpCheckResult(url, false, $"Error: {ex.Message}");
+        }
+    }
+
+    static async Task<HashCheckResult> VerifyHashAsync(UrlInfo url, HttpClient client, TextWriter log)
+    {
+        try
+        {
+            log.Write($"    Downloading {url.FileName}...");
+            using var response = await client.GetAsync(url.Url, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            using var contentStream = await response.Content.ReadAsStreamAsync();
+            using var sha512 = SHA512.Create();
+            byte[] hash = await sha512.ComputeHashAsync(contentStream);
+            string actualHash = Convert.ToHexStringLower(hash);
+            string expectedHash = url.Hash!.ToLowerInvariant();
+            bool match = actualHash == expectedHash;
+            log.WriteLine(match ? " ✅" : " ❌");
+
+            return new HashCheckResult(url, match, expectedHash, actualHash);
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine($" Error: {ex.Message}");
+            return new HashCheckResult(url, false, url.Hash ?? "", $"Error: {ex.Message}");
+        }
+    }
+
+    static string Truncate(string s) => s.Length > 16 ? s[..16] : s;
+
+    private const string CdnFeedBase = "https://builds.dotnet.microsoft.com/dotnet";
+
+    /// <summary>
+    /// Verifies that the dotnet-install.sh latest.version files on the CDN
+    /// match the latest-sdk and latest-runtime values in releases.json.
+    /// </summary>
+    static async Task<List<LinkIssue>> VerifyLatestVersionFilesAsync(
+        string channelVersion, MajorReleaseOverview overview, HttpClient client, TextWriter log)
+    {
+        var issues = new List<LinkIssue>();
+
+        var checks = new (string Component, string UrlPath, string Expected)[]
+        {
+            ("SDK", $"{CdnFeedBase}/Sdk/{channelVersion}/latest.version", overview.LatestSdk),
+            ("Runtime", $"{CdnFeedBase}/Runtime/{channelVersion}/latest.version", overview.LatestRuntime),
+            ("ASP.NET Core Runtime", $"{CdnFeedBase}/aspnetcore/Runtime/{channelVersion}/latest.version",
+                overview.Releases.FirstOrDefault()?.AspnetcoreRuntime.Version ?? ""),
+        };
+
+        foreach (var (component, url, expected) in checks)
+        {
+            if (string.IsNullOrEmpty(expected)) continue;
+
+            try
+            {
+                string actual = (await client.GetStringAsync(url)).Trim();
+                // latest.version may be multi-line (commit hash on first line, version on last)
+                string actualVersion = actual.Contains('\n') ? actual.Split('\n')[^1].Trim() : actual;
+
+                if (actualVersion == expected)
+                {
+                    log.WriteLine($"  ✅ {component} latest.version: {actualVersion}");
+                }
+                else
+                {
+                    log.WriteLine($"  ❌ {component} latest.version: CDN has {actualVersion}, releases.json has {expected}");
+                    issues.Add(new LinkIssue(component, "latest.version", url,
+                        $"CDN has {actualVersion}, releases.json has {expected}"));
+                }
+            }
+            catch (Exception ex)
+            {
+                log.WriteLine($"  ❌ {component} latest.version: {ex.Message}");
+                issues.Add(new LinkIssue(component, "latest.version", url, $"Error: {ex.Message}"));
+            }
+        }
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Collects aka.ms links from ComponentFile.Akams in releases.json and from downloads/*.json files.
+    /// Each link is paired with the expected concrete download URL from releases.json.
+    /// </summary>
+    static List<AkamsInfo> CollectAkamsLinks(
+        PatchRelease release, string version, string releasesNotesPath, TextWriter log)
+    {
+        var links = new List<AkamsInfo>();
+
+        // 1. Collect aka.ms links from ComponentFile.Akams fields in releases.json
+        AddAkamsFromComponent(links, "Runtime", release.Runtime.Files);
+        AddAkamsFromComponent(links, "SDK", release.Sdk.Files);
+        AddAkamsFromComponent(links, "ASP.NET Core", release.AspnetcoreRuntime.Files);
+        if (release.WindowsDesktop is not null)
+            AddAkamsFromComponent(links, "Windows Desktop", release.WindowsDesktop.Files);
+
+        // 2. Collect aka.ms links from downloads/*.json (evergreen redirects)
+        //    These should redirect to the matching file in releases.json
+        var downloadsDir = Path.Combine(releasesNotesPath, version, "downloads");
+        if (Directory.Exists(downloadsDir))
+        {
+            // Build lookup: file name → concrete URL from releases.json
+            var urlByName = BuildFileUrlLookup(release);
+
+            foreach (var jsonFile in Directory.GetFiles(downloadsDir, "*.json"))
+            {
+                if (Path.GetFileName(jsonFile) == "index.json") continue;
+                AddAkamsFromDownloadsFile(links, jsonFile, urlByName, log);
+            }
+        }
+
+        return links;
+    }
+
+    static void AddAkamsFromComponent(List<AkamsInfo> links, string component, IList<ComponentFile> files)
+    {
+        foreach (var file in files)
+        {
+            if (!string.IsNullOrEmpty(file.Akams))
+                links.Add(new AkamsInfo(component, file.Name, file.Akams, file.Url));
+        }
+    }
+
+    /// <summary>
+    /// Builds a lookup from file name to concrete download URL across all components in a patch release.
+    /// </summary>
+    static Dictionary<string, string> BuildFileUrlLookup(PatchRelease release)
+    {
+        var lookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        AddFilesToLookup(lookup, release.Runtime.Files);
+        AddFilesToLookup(lookup, release.Sdk.Files);
+        AddFilesToLookup(lookup, release.AspnetcoreRuntime.Files);
+        if (release.WindowsDesktop is not null)
+            AddFilesToLookup(lookup, release.WindowsDesktop.Files);
+        if (release.Symbols is not null)
+            AddFilesToLookup(lookup, release.Symbols.Files);
+        return lookup;
+    }
+
+    static void AddFilesToLookup(Dictionary<string, string> lookup, IList<ComponentFile> files)
+    {
+        foreach (var file in files)
+        {
+            lookup.TryAdd(file.Name, file.Url);
+        }
+    }
+
+    /// <summary>
+    /// Reads a downloads/*.json file and collects aka.ms → expected URL pairs.
+    /// </summary>
+    static void AddAkamsFromDownloadsFile(
+        List<AkamsInfo> links, string jsonFile, Dictionary<string, string> urlByName, TextWriter log)
+    {
+        try
+        {
+            using var stream = File.OpenRead(jsonFile);
+            var download = JsonSerializer.Deserialize(stream, DownloadsIndexSerializerContext.Default.ComponentDownload);
+            if (download?.Embedded?.Downloads is null) return;
+
+            string component = download.Component ?? Path.GetFileNameWithoutExtension(jsonFile);
+
+            foreach (var (_, file) in download.Embedded.Downloads)
+            {
+                if (file.Links is null) continue;
+
+                if (file.Links.TryGetValue("download", out var downloadLink) &&
+                    downloadLink.Href.Contains("aka.ms", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Match the download file name to the concrete URL in releases.json
+                    if (urlByName.TryGetValue(file.Name, out var expectedUrl))
+                    {
+                        links.Add(new AkamsInfo(component, file.Name, downloadLink.Href, expectedUrl));
+                    }
+                    else
+                    {
+                        // No matching file in releases.json — still check the redirect resolves
+                        links.Add(new AkamsInfo(component, file.Name, downloadLink.Href, ""));
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine($"  ⚠️ Could not read {Path.GetFileName(jsonFile)}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that each aka.ms short link redirects to the expected download URL.
+    /// </summary>
+    static async Task<List<LinkIssue>> VerifyAkamsLinksAsync(
+        List<AkamsInfo> links, TextWriter log)
+    {
+        if (links.Count == 0) return [];
+
+        log.WriteLine($"  Checking {links.Count} aka.ms redirect(s)...");
+
+        // Use a non-redirecting client to inspect the Location header
+        using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+        using var noRedirectClient = new HttpClient(handler);
+        var issues = new List<LinkIssue>();
+        var semaphore = new SemaphoreSlim(16);
+
+        var tasks = links.Select(async link =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                using var response = await noRedirectClient.GetAsync(link.AkamsUrl, HttpCompletionOption.ResponseHeadersRead);
+                string? location = response.Headers.Location?.ToString();
+
+                if (location is null)
+                {
+                    return (link, Issue: $"aka.ms returned {(int)response.StatusCode} with no redirect");
+                }
+
+                if (string.IsNullOrEmpty(link.ExpectedUrl))
+                {
+                    // No releases.json match — just note the redirect target
+                    return (link, Issue: (string?)null);
+                }
+
+                if (location == link.ExpectedUrl)
+                {
+                    return (link, Issue: (string?)null);
+                }
+
+                return (link, Issue: $"Redirects to {location} but releases.json has {link.ExpectedUrl}");
+            }
+            catch (Exception ex)
+            {
+                return (link, Issue: $"Error: {ex.Message}");
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        var results = await Task.WhenAll(tasks);
+        int successCount = 0;
+
+        foreach (var (link, issue) in results)
+        {
+            if (issue is null)
+            {
+                successCount++;
+            }
+            else
+            {
+                log.WriteLine($"  ❌ {link.Component}/{link.FileName}: {issue}");
+                issues.Add(new LinkIssue(link.Component, link.FileName, link.AkamsUrl, issue));
+            }
+        }
+
+        log.WriteLine($"  {successCount}/{links.Count} aka.ms redirects verified");
+        return issues;
+    }
+
+    // Internal types
+    internal record UrlInfo(string Component, string FileName, string Url, string? Hash);
+    record AkamsInfo(string Component, string FileName, string AkamsUrl, string ExpectedUrl);
+    record HttpCheckResult(UrlInfo Url, bool IsSuccess, string StatusDescription);
+    record HashCheckResult(UrlInfo Url, bool IsMatch, string ExpectedHash, string ActualHash);
+}
+
+// --- Markout report models ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ReleasesVerificationReport
+{
+    public string Title => "Release Link Verification";
+
+    [MarkoutPropertyName("Generated")]
+    public string GeneratedAt { get; set; } = "";
+
+    [MarkoutPropertyName("Versions checked")]
+    public string VersionsChecked { get; set; } = "";
+
+    [MarkoutUnwrap]
+    public List<MajorVersionLinkReport> Versions { get; set; } = [];
+
+    [MarkoutIgnore]
+    public bool HasIssues => Versions.Any(v => v.HasIssues);
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class MajorVersionLinkReport
+{
+    [MarkoutIgnore]
+    public string Version { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string PatchVersion { get; set; } = "";
+
+    public string Title => $".NET {Version} — {PatchVersion}";
+
+    [MarkoutPropertyName("URLs checked")]
+    public int UrlsChecked { get; set; }
+
+    [MarkoutUnwrap]
+    public List<LinkIssueBucket> Issues { get; set; } = [];
+
+    [MarkoutIgnore]
+    public bool HasIssues => Issues.Count > 0;
+}
+
+[MarkoutSerializable]
+public class LinkIssueBucket
+{
+    [MarkoutIgnoreInTable]
+    public required Callout Alert { get; init; }
+
+    [MarkoutSection(Name = "")]
+    public List<LinkIssue> Items { get; init; } = [];
+}
+
+[MarkoutSerializable]
+public record LinkIssue(
+    string Component,
+    string File,
+    [property: MarkoutPropertyName("URL")] string Url,
+    string Status);
+
+[MarkoutContext(typeof(ReleasesVerificationReport))]
+[MarkoutContext(typeof(LinkIssue))]
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+public partial class ReleasesVerificationReportContext : MarkoutSerializerContext { }

--- a/src/Dotnet.Release.Tools/releases-template.md
+++ b/src/Dotnet.Release.Tools/releases-template.md
@@ -1,0 +1,21 @@
+# .NET Releases
+
+The .NET team releases new major versions of .NET annually, each November. Releases are either Long Term Support (LTS) or Standard Term Support (STS), and transition from full support through to end-of-life on a defined schedule, per [.NET release policies][policies]. .NET releases are [supported by Microsoft](microsoft-support.md) on [multiple operating systems](os-lifecycle-policy.md) and hardware architectures.
+
+All .NET versions can be downloaded from the [.NET Website](https://dotnet.microsoft.com/download/dotnet), [Linux Package Managers](https://learn.microsoft.com/dotnet/core/install/linux), and the [Microsoft Artifact Registry](https://mcr.microsoft.com/catalog?search=dotnet/).
+
+## Supported releases
+
+The following table lists supported releases.
+
+{{supported}}
+
+{{#if eol}}
+## End-of-life releases
+
+The following table lists end-of-life releases.
+
+{{eol}}
+{{/if}}
+
+[policies]: release-policies.md


### PR DESCRIPTION
Three new commands for the dotnet-release CLI:

## `generate releases-index [path]`

Generates `releases-index.json` from per-version `releases.json` files. Discovers versions by scanning directories and writes the index using `Utf8JsonWriter` for precise output control (avoids AOT issues with nullable/default fields).

## `generate releases [path]`

Generates `releases.md` from per-version `releases.json` files using a Markout template with supported and EOL release tables.

## `verify releases [version] [path] [--skip-hash]`

Validates the latest patch release of each supported version:

- **URL liveness** — HTTP HEAD checks for all download URLs (16 concurrent)
- **SHA512 hash verification** — full file download + hash comparison (4 concurrent, skippable with `--skip-hash`)
- **CDN latest.version** — cross-validates `dotnet-install.sh` version files against `releases.json`
- **aka.ms redirects** — verifies redirects from both `ComponentFile.akams` fields and `downloads/*.json` evergreen links match the concrete URLs in `releases.json`

Optional version filter: channel (`10.0`) or specific patch (`10.0.5`). Exit code 0 = clean, 2 = issues found (markdown report on stdout).

Companion skill PR: https://github.com/dotnet/core/pull/10325