### PR TITLE
Port release-index generators from distroessed

### DIFF
--- a/DotnetRelease.slnx
+++ b/DotnetRelease.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj" />
     <Project Path="src/Dotnet.Release.CveHandler/Dotnet.Release.CveHandler.csproj" />
     <Project Path="src/Dotnet.Release.CveEnricher/Dotnet.Release.CveEnricher.csproj" />
+    <Project Path="src/Dotnet.Release.IndexGenerator/Dotnet.Release.IndexGenerator.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Dotnet.Release.Graph.Tests/Dotnet.Release.Graph.Tests.csproj" />

--- a/src/Dotnet.Release.Graph/Hal.cs
+++ b/src/Dotnet.Release.Graph/Hal.cs
@@ -41,6 +41,83 @@ public class MediaType
     public const string HalJson = "application/hal+json";
     public const string Text = "text/plain";
     public const string Html = "text/html";
+
+    public static List<string> HalJsonFiles { get; } = new()
+    {
+        "index.json",
+        "manifest.json",
+        "timeline/index.json",
+    };
+
+    public static string GetFileType(string filename)
+    {
+        string extension = Path.GetExtension(filename).ToLowerInvariant();
+        if (extension == ".json")
+        {
+            if (HalJsonFiles.Contains(filename, StringComparer.OrdinalIgnoreCase))
+            {
+                return MediaType.HalJson;
+            }
+            else
+            {
+                return MediaType.Json;
+            }
+        }
+
+        return extension switch
+        {
+            ".md" => MediaType.Markdown,
+            _ => MediaType.Text
+        };
+    }
+}
+
+public class HalHelpers
+{
+    public static string GetFileType(ReleaseKind kind) => kind switch
+    {
+        ReleaseKind.Root => MediaType.Json,
+        ReleaseKind.Major => MediaType.Json,
+        ReleaseKind.Patch => MediaType.Json,
+        ReleaseKind.Manifest => MediaType.Json,
+        _ => MediaType.Text
+    };
+
+    /// <summary>
+    /// Orders HAL links with standard relations first (self, prev-*), then HAL+JSON links alphabetically,
+    /// then non-HAL links (JSON, markdown) alphabetically.
+    /// </summary>
+    public static Dictionary<string, HalLink> OrderLinks(Dictionary<string, HalLink> links)
+    {
+        var ordered = new Dictionary<string, HalLink>();
+
+        // Add self first
+        if (links.TryGetValue(HalTerms.Self, out var selfLink))
+            ordered[HalTerms.Self] = selfLink;
+
+        // Add prev-* relations in sorted order
+        foreach (var kvp in links.Where(k => k.Key.StartsWith("prev-")).OrderBy(k => k.Key))
+        {
+            ordered[kvp.Key] = kvp.Value;
+        }
+
+        // Track which keys we've already added
+        var addedKeys = ordered.Keys.ToHashSet();
+
+        // Add HAL+JSON links alphabetically (null type = HAL+JSON default, excluding keys already added)
+        foreach (var kvp in links.Where(k => (k.Value.Type == MediaType.HalJson || k.Value.Type == null) && !addedKeys.Contains(k.Key)).OrderBy(k => k.Key))
+        {
+            ordered[kvp.Key] = kvp.Value;
+        }
+
+        // Add non-HAL+JSON links alphabetically (JSON, markdown, etc.)
+        foreach (var kvp in links.Where(k => k.Value.Type != null && k.Value.Type != MediaType.HalJson).OrderBy(k => k.Key))
+        {
+            ordered[kvp.Key] = kvp.Value;
+        }
+
+        return ordered;
+    }
 }
 
 [Description("Metadata about when and how this document was generated")]

--- a/src/Dotnet.Release.Graph/HistoryYearIndex.cs
+++ b/src/Dotnet.Release.Graph/HistoryYearIndex.cs
@@ -49,6 +49,21 @@ public record HistoryYearIndexEmbedded
     public List<HistoryMonthSummary>? Months { get; set; }
 }
 
+[Description("Detailed month entry with full release and CVE information")]
+public record HistoryMonthEntry(
+    [Description("Month identifier (e.g., '02' for February)")]
+    string Month,
+    [property: JsonPropertyName("_links"),
+     Description("HAL+JSON links for navigation to this month's content")]
+    Dictionary<string, HalLink> Links,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull), Description("CVE security vulnerability records for this month")]
+    IReadOnlyList<CveRecordSummary>? CveRecords,
+    [property: JsonPropertyName("major_releases"), Description("List of .NET major version identifiers that had releases this month")]
+    IList<string> MajorReleases,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull), Description("List of specific patch version identifiers released this month")]
+    IList<string>? PatchReleases
+);
+
 [Description("Simplified month entry for year-level summaries")]
 public record HistoryMonthSummary(
     [Description("Month identifier (e.g., '02' for February)")]

--- a/src/Dotnet.Release.Graph/IndexTitles.cs
+++ b/src/Dotnet.Release.Graph/IndexTitles.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+
+namespace Dotnet.Release.Graph;
+
+/// <summary>
+/// Standard titles and descriptions for .NET release indexes
+/// Uses string interning to ensure single instances of commonly used strings
+/// </summary>
+public static class IndexTitles
+{
+    // Month name lookup for human-friendly date formatting
+    private static readonly string[] MonthNames = CultureInfo.InvariantCulture.DateTimeFormat.MonthNames;
+
+    /// <summary>
+    /// Formats a year and month as "December 2024" style string
+    /// </summary>
+    public static string FormatMonthYear(string year, string month) =>
+        int.TryParse(month, out var m) && m >= 1 && m <= 12
+            ? $"{MonthNames[m - 1]} {year}"
+            : $"{year}-{month}";
+
+    // Version Index (organized by version number)
+    public static readonly string VersionIndexTitle = string.Intern(".NET Release Index");
+    public static readonly string VersionIndexLink = string.Intern(".NET Release Index");
+
+    // Timeline Index (organized chronologically)
+    public static readonly string TimelineIndexTitle = string.Intern(".NET Release Timeline Index");
+    public static readonly string TimelineIndexLink = string.Intern(".NET Release Timeline Index");
+
+    // Year-level timeline
+    public static string TimelineYearTitle(string year) => string.Intern($".NET Year Timeline Index - {year}");
+    public static string TimelineYearDescription(string year) => string.Intern($".NET release timeline - {year}");
+    public static string TimelineYearLink(string year) => string.Intern($".NET Year Timeline Index - {year}");
+
+    // Month-level timeline
+    public static string TimelineMonthTitle(string year, string month) => string.Intern($".NET Month Timeline Index - {FormatMonthYear(year, month)}");
+    public static string TimelineMonthLink(string year, string month) => string.Intern($".NET Month Timeline Index - {FormatMonthYear(year, month)}");
+
+    // Description patterns
+    public static string VersionIndexDescription(string latestVersion) =>
+        string.Intern($".NET Release Index (latest: {latestVersion})");
+
+    public static string TimelineIndexDescription(string latestVersion) =>
+        string.Intern($".NET Release Timeline (latest: {latestVersion})");
+
+    public static string TimelineYearIndexDescription(string year, string latestVersion) =>
+        string.Intern($"Release timeline - {year} (latest: {latestVersion})");
+
+    public static string TimelineMonthIndexDescription(string year, string month, string latestVersion) =>
+        string.Intern($"Release timeline - {FormatMonthYear(year, month)} (latest: {latestVersion})");
+}

--- a/src/Dotnet.Release.Graph/LinkTitles.cs
+++ b/src/Dotnet.Release.Graph/LinkTitles.cs
@@ -1,0 +1,54 @@
+namespace Dotnet.Release.Graph;
+
+/// <summary>
+/// Standard link titles for .NET release index files
+/// Uses string interning to ensure single instances of commonly used strings.
+/// Titles are kind-based (semantic) rather than instance-specific to reduce file size.
+/// </summary>
+public static class LinkTitles
+{
+    // Index titles (kind-based, not version-specific)
+    public static readonly string Index = string.Intern("Index");
+    public static readonly string ReleaseIndex = string.Intern("Release index");
+    public static readonly string MajorVersionIndex = string.Intern("Major version index");
+    public static readonly string PatchIndex = string.Intern("Patch index");
+    public static readonly string SdkIndex = string.Intern("SDK index");
+    public static readonly string DownloadsIndex = string.Intern("Downloads index");
+    public static readonly string TimelineIndex = string.Intern("Timeline index");
+    public static readonly string TimelineYearIndex = string.Intern("Timeline year index");
+    public static readonly string TimelineMonthIndex = string.Intern("Release month index");
+
+    // Legacy (for backward compatibility in some contexts)
+    public static readonly string HistoryIndex = string.Intern("History Index");
+    public static readonly string DotNetReleaseIndex = string.Intern(".NET Release Index");
+    public static readonly string DotNetReleaseNotes = string.Intern(".NET Release Notes");
+    public static readonly string ReleaseNotes = string.Intern("Release Notes");
+    public static readonly string Release = string.Intern("Release");
+    public static readonly string ReleaseManifest = string.Intern("Release manifest");
+    public static readonly string CompleteReleaseInformation = string.Intern("Complete (large file) release information for all patch releases");
+
+    // CVE-related
+    public static readonly string CveRecordsJson = string.Intern("CVE records (JSON)");
+    public static readonly string CveMarkdown = string.Intern("CVE records");
+
+    // Latest pointers (kind-based)
+    public static readonly string LatestPatch = string.Intern("Latest patch");
+    public static readonly string LatestSecurityPatch = string.Intern("Latest security patch");
+    public static readonly string LatestLts = string.Intern("Latest LTS");
+    public static readonly string Sdk = string.Intern("SDK");
+
+    // Support and documentation
+    public static readonly string SupportPolicy = string.Intern("Support Policy");
+    public static readonly string UsageGuide = string.Intern("Usage Guide");
+    public static readonly string QuickReference = string.Intern("Quick Reference");
+    public static readonly string Glossary = string.Intern("Glossary");
+
+    // OS and packages
+    public static readonly string SupportedOSes = string.Intern("Supported OSes");
+    public static readonly string OsPackages = string.Intern("OS Packages");
+    public static readonly string LinuxPackages = string.Intern("Linux Packages");
+
+    // Reference data
+    public static readonly string Compatibility = string.Intern("Compatibility");
+    public static readonly string TargetFrameworks = string.Intern("Target Frameworks");
+}

--- a/src/Dotnet.Release.Graph/LlmsIndex.cs
+++ b/src/Dotnet.Release.Graph/LlmsIndex.cs
@@ -95,6 +95,23 @@ public record LlmsPatchEntry(
      Description("HAL+JSON links")]
     Dictionary<string, HalLink> Links);
 
+[Description("Partial LLMs index for hand-maintained fields")]
+public record PartialLlmsIndex
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Note for AI assistants on how to navigate this graph")]
+    public string? AiNote { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Override title if needed")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("_links"),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Additional links to merge")]
+    public Dictionary<string, HalLink>? Links { get; init; }
+}
+
 [Description("Navigation workflow for common queries")]
 public record LlmsWorkflow
 {

--- a/src/Dotnet.Release.Graph/Manifest.cs
+++ b/src/Dotnet.Release.Graph/Manifest.cs
@@ -42,3 +42,52 @@ public record ReleaseManifest(
      Description("HAL+JSON links for hypermedia navigation")]
     public Dictionary<string, HalLink> Links { get; init; } = [];
 }
+
+[Description("Partial manifest data for hand-maintained release information - schema compatible with ReleaseManifest")]
+public record PartialManifest
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Type of release document, always 'manifest'")]
+    public ReleaseKind? Kind { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Concise title for the document")]
+    public string? Title { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Major version identifier (e.g., '8.0')")]
+    public string? Version { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Human-friendly version label (e.g., '.NET 8.0')")]
+    public string? Label { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Target framework moniker for this version")]
+    public string? TargetFramework { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Release type: lts or sts")]
+    public ReleaseType? ReleaseType { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Current support phase")]
+    public SupportPhase? SupportPhase { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Whether this version is currently supported")]
+    public bool? Supported { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("General Availability date")]
+    public DateTimeOffset? GaDate { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("End of Life date")]
+    public DateTimeOffset? EolDate { get; init; }
+
+    [JsonPropertyName("_links"),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("HAL+JSON links")]
+    public Dictionary<string, HalLink>? Links { get; init; }
+}

--- a/src/Dotnet.Release.Graph/ReleaseVersionIndex.cs
+++ b/src/Dotnet.Release.Graph/ReleaseVersionIndex.cs
@@ -81,3 +81,58 @@ public enum ReleaseKind
     [Description("Unspecified type")]
     Unknown
 }
+
+/// <summary>
+/// Legacy type for backward compatibility - prefer MajorReleaseVersionIndex or PatchReleaseVersionIndex
+/// </summary>
+[Description("Legacy index type - use MajorReleaseVersionIndex or PatchReleaseVersionIndex instead")]
+public record ReleaseVersionIndex(
+    [Description("Type of release document")]
+    ReleaseKind Kind,
+    [Description("Concise title for the document")]
+    string Title,
+    [Description("Description of the index scope")]
+    string Description,
+    [property: JsonPropertyName("_links"),
+     Description("HAL+JSON links for hypermedia navigation")]
+    Dictionary<string, HalLink> Links) : IReleaseVersionIndex
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Usage information and term definitions")]
+    public UsageWithLinks? Usage { get; set; }
+
+    [JsonPropertyName("_embedded"),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Embedded release entries for this index level")]
+    public ReleaseVersionIndexEmbedded? Embedded { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Lifecycle information")]
+    public Lifecycle? Lifecycle { get; set; }
+}
+
+[Description("Container for embedded release entries in a version index (legacy)")]
+public record ReleaseVersionIndexEmbedded(
+    [Description("List of release entries")]
+    List<ReleaseVersionIndexEntry> Releases);
+
+[Description("Individual release entry within a version index (legacy)")]
+public record ReleaseVersionIndexEntry(
+    [Description("Version identifier")]
+    string Version,
+    [property: JsonPropertyName("_links"),
+     Description("HAL+JSON links for navigation")]
+    Dictionary<string, HalLink> Links)
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Lifecycle information (phase and release-date)")]
+    public PatchLifecycle? Lifecycle { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("CVE IDs associated with this release")]
+    public IReadOnlyList<string>? CveRecords { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("SDK versions included in this patch release")]
+    public IReadOnlyList<string>? SdkVersions { get; set; }
+}

--- a/src/Dotnet.Release.Graph/SerializerContexts.cs
+++ b/src/Dotnet.Release.Graph/SerializerContexts.cs
@@ -21,6 +21,7 @@ public partial class ReleaseVersionIndexSerializerContext : JsonSerializerContex
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     WriteIndented = true)]
 [JsonSerializable(typeof(ReleaseManifest))]
+[JsonSerializable(typeof(PartialManifest))]
 public partial class ReleaseManifestSerializerContext : JsonSerializerContext
 {
 }
@@ -78,6 +79,7 @@ public partial class TargetFrameworksSerializerContext : JsonSerializerContext
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     WriteIndented = true)]
 [JsonSerializable(typeof(LlmsIndex))]
+[JsonSerializable(typeof(PartialLlmsIndex))]
 [JsonSerializable(typeof(LlmsWorkflow))]
 [JsonSerializable(typeof(HistoryMonthSummary))]
 public partial class LlmsIndexSerializerContext : JsonSerializerContext

--- a/src/Dotnet.Release.IndexGenerator/Dotnet.Release.IndexGenerator.csproj
+++ b/src/Dotnet.Release.IndexGenerator/Dotnet.Release.IndexGenerator.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dotnet.Release.IndexGenerator</PackageId>
+    <Description>Generators for .NET release HAL+JSON index files</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Dotnet.Release\Summary\**\*.cs" LinkBase="Summary" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Graph\Dotnet.Release.Graph.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.Releases\Dotnet.Release.Releases.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.CveHandler\Dotnet.Release.CveHandler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dotnet.Release.IndexGenerator/DownloadsIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/DownloadsIndexFiles.cs
@@ -1,0 +1,400 @@
+using System.Globalization;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Summary;
+
+namespace Dotnet.Release.IndexGenerator;
+
+/// <summary>
+/// Generates the downloads/ directory with component download files for each major version.
+/// </summary>
+public class DownloadsIndexFiles
+{
+    // Runtime download files (cross-platform)
+    private static readonly List<(string FileName, string Rid, string Os, string Arch)> RuntimeDownloads =
+    [
+        ("dotnet-runtime-linux-arm.tar.gz", "linux-arm", "linux", "arm"),
+        ("dotnet-runtime-linux-arm64.tar.gz", "linux-arm64", "linux", "arm64"),
+        ("dotnet-runtime-linux-musl-arm.tar.gz", "linux-musl-arm", "linux-musl", "arm"),
+        ("dotnet-runtime-linux-musl-arm64.tar.gz", "linux-musl-arm64", "linux-musl", "arm64"),
+        ("dotnet-runtime-linux-musl-x64.tar.gz", "linux-musl-x64", "linux-musl", "x64"),
+        ("dotnet-runtime-linux-x64.tar.gz", "linux-x64", "linux", "x64"),
+        ("dotnet-runtime-osx-arm64.tar.gz", "osx-arm64", "osx", "arm64"),
+        ("dotnet-runtime-osx-x64.tar.gz", "osx-x64", "osx", "x64"),
+        ("dotnet-runtime-win-arm64.zip", "win-arm64", "win", "arm64"),
+        ("dotnet-runtime-win-x64.zip", "win-x64", "win", "x64"),
+        ("dotnet-runtime-win-x86.zip", "win-x86", "win", "x86"),
+    ];
+
+    // ASP.NET Core Runtime download files (cross-platform)
+    private static readonly List<(string FileName, string Rid, string Os, string Arch)> AspNetCoreDownloads =
+    [
+        ("aspnetcore-runtime-linux-arm.tar.gz", "linux-arm", "linux", "arm"),
+        ("aspnetcore-runtime-linux-arm64.tar.gz", "linux-arm64", "linux", "arm64"),
+        ("aspnetcore-runtime-linux-musl-arm.tar.gz", "linux-musl-arm", "linux-musl", "arm"),
+        ("aspnetcore-runtime-linux-musl-arm64.tar.gz", "linux-musl-arm64", "linux-musl", "arm64"),
+        ("aspnetcore-runtime-linux-musl-x64.tar.gz", "linux-musl-x64", "linux-musl", "x64"),
+        ("aspnetcore-runtime-linux-x64.tar.gz", "linux-x64", "linux", "x64"),
+        ("aspnetcore-runtime-osx-arm64.tar.gz", "osx-arm64", "osx", "arm64"),
+        ("aspnetcore-runtime-osx-x64.tar.gz", "osx-x64", "osx", "x64"),
+        ("aspnetcore-runtime-win-arm64.zip", "win-arm64", "win", "arm64"),
+        ("aspnetcore-runtime-win-x64.zip", "win-x64", "win", "x64"),
+        ("aspnetcore-runtime-win-x86.zip", "win-x86", "win", "x86"),
+    ];
+
+    // Windows Desktop Runtime download files (Windows only)
+    private static readonly List<(string FileName, string Rid, string Os, string Arch)> WindowsDesktopDownloads =
+    [
+        ("windowsdesktop-runtime-win-arm64.exe", "win-arm64", "win", "arm64"),
+        ("windowsdesktop-runtime-win-x64.exe", "win-x64", "win", "x64"),
+        ("windowsdesktop-runtime-win-x86.exe", "win-x86", "win", "x86"),
+    ];
+
+    // SDK download files (cross-platform)
+    private static readonly List<(string FileName, string Rid, string Os, string Arch)> SdkDownloads =
+    [
+        ("dotnet-sdk-linux-arm.tar.gz", "linux-arm", "linux", "arm"),
+        ("dotnet-sdk-linux-arm64.tar.gz", "linux-arm64", "linux", "arm64"),
+        ("dotnet-sdk-linux-musl-arm.tar.gz", "linux-musl-arm", "linux-musl", "arm"),
+        ("dotnet-sdk-linux-musl-arm64.tar.gz", "linux-musl-arm64", "linux-musl", "arm64"),
+        ("dotnet-sdk-linux-musl-x64.tar.gz", "linux-musl-x64", "linux-musl", "x64"),
+        ("dotnet-sdk-linux-x64.tar.gz", "linux-x64", "linux", "x64"),
+        ("dotnet-sdk-osx-arm64.tar.gz", "osx-arm64", "osx", "arm64"),
+        ("dotnet-sdk-osx-x64.tar.gz", "osx-x64", "osx", "x64"),
+        ("dotnet-sdk-win-arm64.zip", "win-arm64", "win", "arm64"),
+        ("dotnet-sdk-win-x64.zip", "win-x64", "win", "x64"),
+        ("dotnet-sdk-win-x86.zip", "win-x86", "win", "x86"),
+    ];
+
+    /// <summary>
+    /// Generates downloads directory files for all major versions that support it (8.0+).
+    /// </summary>
+    public static async Task GenerateAsync(List<MajorReleaseSummary> summaries, string rootDir)
+    {
+        if (!Directory.Exists(rootDir))
+        {
+            throw new DirectoryNotFoundException($"Root directory does not exist: {rootDir}");
+        }
+
+        var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+
+        foreach (var summary in summaries)
+        {
+            // Only generate downloads for .NET 8.0 and later
+            if (!IsVersionSupported(summary.MajorVersion))
+            {
+                continue;
+            }
+
+            var majorVersionDir = Path.Combine(rootDir, summary.MajorVersion);
+            if (!Directory.Exists(majorVersionDir))
+            {
+                continue;
+            }
+
+            Console.WriteLine($"Generating downloads directory for .NET {summary.MajorVersion}");
+
+            var downloadsDir = Path.Combine(majorVersionDir, FileNames.Directories.Downloads);
+            Directory.CreateDirectory(downloadsDir);
+
+            // Generate component download files
+            await GenerateRuntimeDownloadAsync(summary, downloadsDir, rootDir);
+            await GenerateAspNetCoreDownloadAsync(summary, downloadsDir, rootDir);
+            await GenerateWindowsDesktopDownloadAsync(summary, downloadsDir, rootDir);
+            await GenerateSdkDownloadAsync(summary, downloadsDir, rootDir);
+
+            // Generate feature band download files
+            await GenerateFeatureBandDownloadsAsync(summary, downloadsDir, rootDir, numericStringComparer);
+
+            // Generate downloads index
+            await GenerateDownloadsIndexAsync(summary, downloadsDir, rootDir, numericStringComparer);
+        }
+    }
+
+    private static bool IsVersionSupported(string version)
+    {
+        // Downloads directory is only supported for .NET 8.0 and later
+        if (string.IsNullOrEmpty(version) || !version.Contains('.'))
+        {
+            return false;
+        }
+
+        var parts = version.Split('.');
+        if (parts.Length < 2 || !int.TryParse(parts[0], out var major))
+        {
+            return false;
+        }
+
+        return major >= 8;
+    }
+
+    private static async Task GenerateDownloadsIndexAsync(
+        MajorReleaseSummary summary,
+        string downloadsDir,
+        string rootDir,
+        StringComparer numericStringComparer)
+    {
+        var indexPath = Path.Combine(downloadsDir, FileNames.Index);
+        var indexRelativePath = $"{summary.MajorVersion}/{FileNames.Directories.Downloads}/{FileNames.Index}";
+
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{indexRelativePath}"),
+            [LinkRelations.Major] = new HalLink($"{Location.GitHubBaseUri}{summary.MajorVersion}/{FileNames.Index}")
+            {
+                Title = $".NET {summary.MajorVersion}",
+            }
+        };
+
+        // Build component entries
+        var components = new List<ComponentEntry>
+        {
+            CreateComponentEntry("runtime", ".NET Runtime", summary.MajorVersion),
+            CreateComponentEntry("aspnetcore", "ASP.NET Core Runtime", summary.MajorVersion),
+            CreateComponentEntry("windowsdesktop", "Windows Desktop Runtime", summary.MajorVersion),
+            CreateSdkComponentEntry(summary.MajorVersion),
+        };
+
+        // Build feature band entries (sorted by version descending)
+        var featureBands = summary.SdkBands
+            .OrderByDescending(b => b.Version, numericStringComparer)
+            .Select(band =>
+            {
+                var bandVersion = band.Version[..5] + "xx"; // e.g., "8.0.4xx"
+                var bandFileName = $"sdk-{bandVersion}.json";
+                var bandRelativePath = $"{summary.MajorVersion}/{FileNames.Directories.Downloads}/{bandFileName}";
+
+                // Note: No titles or types in _embedded links - context established by parent
+                var bandLinks = new Dictionary<string, HalLink>
+                {
+                    [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{bandRelativePath}")
+                };
+
+                return new FeatureBandEntry(bandVersion, $".NET SDK {bandVersion}", band.SupportPhase)
+                {
+                    Links = bandLinks
+                };
+            })
+            .ToList();
+
+        var downloadsIndex = new DownloadsIndex(
+            ReleaseKind.Downloads,
+            summary.MajorVersion,
+            $".NET {summary.MajorVersion} Downloads")
+        {
+            Links = HalHelpers.OrderLinks(links),
+            Embedded = new DownloadsIndexEmbedded
+            {
+                Components = components,
+                FeatureBands = featureBands.Count > 0 ? featureBands : null
+            }
+        };
+
+        var json = JsonSerializer.Serialize(
+            downloadsIndex,
+            DownloadsIndexSerializerContext.Default.DownloadsIndex);
+
+        var schemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.DownloadsIndex}";
+        var jsonWithSchema = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(json, schemaUri);
+
+        await File.WriteAllTextAsync(indexPath, (jsonWithSchema ?? json) + '\n');
+    }
+
+    // Note: No titles or types in _embedded links - context established by parent
+    private static ComponentEntry CreateComponentEntry(string name, string title, string version)
+    {
+        var fileName = $"{name}.json";
+        var relativePath = $"{version}/{FileNames.Directories.Downloads}/{fileName}";
+
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{relativePath}")
+        };
+
+        return new ComponentEntry(name, title) { Links = links };
+    }
+
+    private static ComponentEntry CreateSdkComponentEntry(string version)
+    {
+        var fileName = "sdk.json";
+        var relativePath = $"{version}/{FileNames.Directories.Downloads}/{fileName}";
+        var sdkIndexPath = $"{version}/{FileNames.Directories.Sdk}/{FileNames.Index}";
+
+        // Note: No titles or types in _embedded links - context established by parent
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{relativePath}"),
+            ["sdk-index"] = new HalLink($"{Location.GitHubBaseUri}{sdkIndexPath}")
+        };
+
+        return new ComponentEntry("sdk", ".NET SDK") { Links = links };
+    }
+
+    private static async Task GenerateRuntimeDownloadAsync(MajorReleaseSummary summary, string downloadsDir, string rootDir)
+    {
+        await GenerateComponentDownloadAsync(
+            summary.MajorVersion,
+            "runtime",
+            ".NET Runtime",
+            $"Evergreen download links for .NET Runtime {summary.MajorVersion}",
+            RuntimeDownloads,
+            "dotnet-runtime",
+            downloadsDir,
+            rootDir);
+    }
+
+    private static async Task GenerateAspNetCoreDownloadAsync(MajorReleaseSummary summary, string downloadsDir, string rootDir)
+    {
+        await GenerateComponentDownloadAsync(
+            summary.MajorVersion,
+            "aspnetcore",
+            "ASP.NET Core Runtime",
+            $"Evergreen download links for ASP.NET Core Runtime {summary.MajorVersion}",
+            AspNetCoreDownloads,
+            "aspnetcore-runtime",
+            downloadsDir,
+            rootDir);
+    }
+
+    private static async Task GenerateWindowsDesktopDownloadAsync(MajorReleaseSummary summary, string downloadsDir, string rootDir)
+    {
+        await GenerateComponentDownloadAsync(
+            summary.MajorVersion,
+            "windowsdesktop",
+            "Windows Desktop Runtime",
+            $"Evergreen download links for Windows Desktop Runtime {summary.MajorVersion}",
+            WindowsDesktopDownloads,
+            "windowsdesktop-runtime",
+            downloadsDir,
+            rootDir);
+    }
+
+    private static async Task GenerateSdkDownloadAsync(MajorReleaseSummary summary, string downloadsDir, string rootDir)
+    {
+        // sdk.json uses major version URLs (aka.ms/dotnet/8.0/...)
+        await GenerateComponentDownloadAsync(
+            summary.MajorVersion,
+            "sdk",
+            ".NET SDK",
+            $"Evergreen download links for .NET SDK {summary.MajorVersion} (latest feature band)",
+            SdkDownloads,
+            "dotnet-sdk",
+            downloadsDir,
+            rootDir,
+            featureBand: null,
+            includeSdkIndexLink: true);
+    }
+
+    private static async Task GenerateFeatureBandDownloadsAsync(
+        MajorReleaseSummary summary,
+        string downloadsDir,
+        string rootDir,
+        StringComparer numericStringComparer)
+    {
+        foreach (var band in summary.SdkBands)
+        {
+            var bandVersion = band.Version[..5] + "xx"; // e.g., "8.0.4xx"
+            var fileName = $"sdk-{bandVersion}.json";
+            var filePath = Path.Combine(downloadsDir, fileName);
+
+            await GenerateComponentDownloadAsync(
+                summary.MajorVersion,
+                "sdk",
+                $".NET SDK {bandVersion}",
+                $"Evergreen download links for .NET SDK {bandVersion} feature band",
+                SdkDownloads,
+                "dotnet-sdk",
+                downloadsDir,
+                rootDir,
+                featureBand: bandVersion,
+                includeSdkIndexLink: true,
+                customFileName: fileName);
+        }
+    }
+
+    private static async Task GenerateComponentDownloadAsync(
+        string version,
+        string component,
+        string title,
+        string description,
+        List<(string FileName, string Rid, string Os, string Arch)> downloads,
+        string filePrefix,
+        string downloadsDir,
+        string rootDir,
+        string? featureBand = null,
+        bool includeSdkIndexLink = false,
+        string? customFileName = null)
+    {
+        var fileName = customFileName ?? $"{component}.json";
+        var filePath = Path.Combine(downloadsDir, fileName);
+        var relativePath = $"{version}/{FileNames.Directories.Downloads}/{fileName}";
+        var downloadVersion = featureBand ?? version; // Use feature band for SDK band files, version otherwise
+
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{relativePath}")
+            {
+                Type = MediaType.Json
+            },
+            ["downloads-index"] = new HalLink($"{Location.GitHubBaseUri}{version}/{FileNames.Directories.Downloads}/{FileNames.Index}")
+            {
+                Title = $".NET {version} Downloads",
+            },
+            [LinkRelations.Major] = new HalLink($"{Location.GitHubBaseUri}{version}/{FileNames.Index}")
+            {
+                Title = $".NET {version}",
+            }
+        };
+
+        if (includeSdkIndexLink)
+        {
+            links["sdk-index"] = new HalLink($"{Location.GitHubBaseUri}{version}/{FileNames.Directories.Sdk}/{FileNames.Index}")
+            {
+                Title = $".NET SDK {version}",
+            };
+        }
+
+        // Build download file entries
+        var downloadFiles = new Dictionary<string, DownloadFile>();
+        foreach (var (fn, rid, os, arch) in downloads)
+        {
+            var downloadLinks = new Dictionary<string, HalLink>
+            {
+                ["download"] = new HalLink($"https://aka.ms/dotnet/{downloadVersion}/{fn}")
+                {
+                    Title = $"Download {fn}"
+                },
+                ["hash"] = new HalLink($"https://aka.ms/dotnet/{downloadVersion}/{fn}.sha512")
+                {
+                    Title = "SHA512 hash file"
+                }
+            };
+
+            downloadFiles[rid] = new DownloadFile(fn, rid, os, arch, "sha512")
+            {
+                Links = downloadLinks
+            };
+        }
+
+        var componentDownload = new ComponentDownload(
+            ReleaseKind.ComponentDownload,
+            component,
+            version,
+            $"{title} Downloads")
+        {
+            FeatureBand = featureBand,
+            Links = HalHelpers.OrderLinks(links),
+            Embedded = new ComponentDownloadEmbedded(downloadFiles)
+        };
+
+        var json = JsonSerializer.Serialize(
+            componentDownload,
+            DownloadsIndexSerializerContext.Default.ComponentDownload);
+
+        var schemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.ComponentDownload}";
+        var jsonWithSchema = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(json, schemaUri);
+
+        await File.WriteAllTextAsync(filePath, (jsonWithSchema ?? json) + '\n');
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/JsonSchemaInjector.cs
+++ b/src/Dotnet.Release.IndexGenerator/JsonSchemaInjector.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+
+namespace JsonSchemaInjector;
+
+public static class JsonSchemaInjector
+{
+    /// <summary>
+    /// Adds a $schema property to JSON content.
+    /// </summary>
+    /// <param name="jsonContent">JSON content as string</param>
+    /// <param name="schemaUri">URI of the schema to add</param>
+    /// <returns>Updated JSON content with $schema property, or null if parsing failed</returns>
+    public static string? AddSchemaToContent(string jsonContent, string schemaUri)
+    {
+        try
+        {
+            // Parse as JsonDocument to preserve property order
+            using var jsonDoc = JsonDocument.Parse(jsonContent);
+            var root = jsonDoc.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            // Use a MemoryStream and Utf8JsonWriter to build the JSON with proper ordering
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+            
+            writer.WriteStartObject();
+            
+            // Write $schema first
+            writer.WriteString("$schema", schemaUri);
+            
+            // Copy all other properties in their original order
+            foreach (var property in root.EnumerateObject())
+            {
+                if (property.Name != "$schema") // Skip if it already exists
+                {
+                    property.WriteTo(writer);
+                }
+            }
+            
+            writer.WriteEndObject();
+            writer.Flush();
+            
+            // Convert to string
+            return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/LinkHelpers.cs
+++ b/src/Dotnet.Release.IndexGenerator/LinkHelpers.cs
@@ -1,0 +1,22 @@
+using Dotnet.Release;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class LinkHelpers
+{
+    public static string GetProdPath(string relativePath) => GetRawGitHubBranchPath(relativePath);
+
+    public static string GetCdnPath(string relativePath) =>
+      $"https://builds.dotnet.microsoft.com/dotnet/release-metadata/{relativePath}";
+
+
+    public static string GetRawGitHubPath(string relativePath) =>
+      $"https://raw.githubusercontent.com/dotnet/core/main/release-notes/{relativePath}";
+
+    public static string GetRawGitHubBranchPath(string relativePath) =>
+      $"{Location.GitHubBaseUri}{relativePath}";
+
+
+    public static string GetGitHubPath(string relativePath) =>
+    $"https://github.com/dotnet/core/blob/main/release-notes/{relativePath}";
+}

--- a/src/Dotnet.Release.IndexGenerator/LlmsIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/LlmsIndexFiles.cs
@@ -1,0 +1,356 @@
+using System.Globalization;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Summary;
+using Dotnet.Release.CveHandler;
+
+namespace Dotnet.Release.IndexGenerator;
+
+// Alias to avoid conflict with Dotnet.Release.Graph.LlmsIndex record
+using LlmsIndexRecord = Dotnet.Release.Graph.LlmsIndex;
+
+public static class LlmsIndexFiles
+{
+    public static async Task GenerateAsync(
+        string inputDir,
+        string outputDir,
+        List<MajorReleaseSummary> summaries,
+        ReleaseHistory releaseHistory)
+    {
+        var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+
+        // Load partial _llms.json for hand-maintained fields (ai_note, etc.)
+        PartialLlmsIndex? partial = null;
+        var partialPath = Path.Combine(inputDir, FileNames.PartialLlms);
+        if (File.Exists(partialPath))
+        {
+            try
+            {
+                var partialJson = await File.ReadAllTextAsync(partialPath);
+                partial = JsonSerializer.Deserialize<PartialLlmsIndex>(partialJson, LlmsIndexSerializerContext.Default.PartialLlmsIndex);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Failed to read {partialPath}: {ex.Message}");
+            }
+        }
+
+        // Find supported releases (those with Supported = true)
+        var supportedSummaries = summaries
+            .Where(s => s.Lifecycle?.Supported == true)
+            .OrderByDescending(s => s.MajorVersion, numericStringComparer)
+            .ToList();
+
+        var supportedReleases = supportedSummaries
+            .Select(s => s.MajorVersion)
+            .ToList();
+
+        // Find latest stable release and latest LTS release
+        var releaseData = summaries.Select(s => (s.MajorVersion, (Lifecycle?)s.Lifecycle));
+        var latestVersion = ReleaseStability.FindLatestVersion(releaseData, numericStringComparer);
+        var latestLtsVersion = ReleaseStability.FindLatestLtsVersion(releaseData, numericStringComparer);
+
+        // Get the latest year from release history
+        var latestYear = releaseHistory.Years.Keys
+            .OrderByDescending(y => y, numericStringComparer)
+            .FirstOrDefault();
+
+        // Build latest patches collection
+        var latestPatches = new Dictionary<string, LlmsPatchEntry>();
+        foreach (var summary in supportedSummaries)
+        {
+            var latestPatch = summary.PatchReleases
+                .OrderByDescending(p => p.ReleaseDate)
+                .ThenByDescending(p => p.PatchVersion, numericStringComparer)
+                .FirstOrDefault();
+
+            if (latestPatch == null) continue;
+
+            var releaseDate = new DateTimeOffset(latestPatch.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero);
+
+            // Get SDK version from components
+            var sdkVersion = latestPatch.Components?
+                .Where(c => c.Name == "SDK")
+                .Select(c => c.Version)
+                .OrderByDescending(v => v, numericStringComparer)
+                .FirstOrDefault();
+
+            // Get CVE IDs for this patch (from cve.json via release history)
+            IReadOnlyList<string>? cveIds = null;
+            var cveRecords = await CveLoader.LoadForReleaseDateAsync(inputDir, releaseDate);
+            if (cveRecords?.ReleaseCves != null && cveRecords.ReleaseCves.TryGetValue(summary.MajorVersion, out var cveIdsFromCveJson))
+            {
+                cveIds = cveIdsFromCveJson.ToList();
+            }
+
+            // Build patch entry links - self points to patch index
+            // Note: No titles in embedded links - context established by parent, saves tokens for LLM consumers
+            var patchDirPath = latestPatch.PatchDirPath ?? $"{summary.MajorVersion}/{latestPatch.PatchVersion}";
+            var patchIndexPath = $"{patchDirPath}/{FileNames.Index}";
+            var patchLinks = new Dictionary<string, HalLink>
+            {
+                [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{patchIndexPath}")
+            };
+
+            // Add latest-month link to timeline month for this patch's release date
+            var patchYear = latestPatch.ReleaseDate.Year.ToString("D4");
+            var patchMonth = latestPatch.ReleaseDate.Month.ToString("D2");
+            patchLinks[LinkRelations.LatestMonth] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{patchYear}/{patchMonth}/{FileNames.Index}");
+
+            // Find latest security patch for this release (for quick hop when security=false)
+            var latestSecurityPatch = summary.PatchReleases
+                .Where(p => p.CveList?.Count > 0)
+                .OrderByDescending(p => p.ReleaseDate)
+                .ThenByDescending(p => p.PatchVersion, numericStringComparer)
+                .FirstOrDefault();
+
+            if (latestSecurityPatch != null)
+            {
+                var securityPatchDirPath = latestSecurityPatch.PatchDirPath ?? $"{summary.MajorVersion}/{latestSecurityPatch.PatchVersion}";
+                var securityPatchIndexPath = $"{securityPatchDirPath}/{FileNames.Index}";
+                patchLinks[LinkRelations.LatestSecurityPatch] = new HalLink($"{Location.GitHubBaseUri}{securityPatchIndexPath}");
+
+                // Add latest-security-month link to timeline month for this release's security patch
+                var securityYear = latestSecurityPatch.ReleaseDate.Year.ToString("D4");
+                var securityMonth = latestSecurityPatch.ReleaseDate.Month.ToString("D2");
+                var securityMonthUrl = $"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{securityYear}/{securityMonth}/{FileNames.Index}";
+                patchLinks[LinkRelations.LatestSecurityMonth] = new HalLink(securityMonthUrl);
+
+                // Add latest-security-disclosures as semantic alias
+                patchLinks[LinkRelations.LatestSecurityDisclosures] = new HalLink(securityMonthUrl);
+            }
+
+            // Add release-major link to navigate to the major version index
+            patchLinks[LinkRelations.Major] = new HalLink($"{Location.GitHubBaseUri}{summary.MajorVersion}/{FileNames.Index}");
+
+            // Add downloads link for versions that support SDK hive (8.0+)
+            var majorVersionParts = summary.MajorVersion.Split('.');
+            if (majorVersionParts.Length >= 1 && int.TryParse(majorVersionParts[0], out var majorNum) && majorNum >= 8)
+            {
+                patchLinks[LinkRelations.Downloads] = new HalLink($"{Location.GitHubBaseUri}{summary.MajorVersion}/{FileNames.Directories.Downloads}/{FileNames.Index}");
+            }
+
+            // Add manifest link for direct access to reference data (compatibility, TFMs, OS support)
+            patchLinks[LinkRelations.Manifest] = new HalLink($"{Location.GitHubBaseUri}{summary.MajorVersion}/{FileNames.Manifest}");
+
+            // Skip entries without complete lifecycle data
+            if (summary.Lifecycle == null || summary.Lifecycle.ReleaseType == null)
+            {
+                continue;
+            }
+
+            // Skip entries without SDK version (shouldn't happen for supported releases)
+            if (sdkVersion == null)
+            {
+                continue;
+            }
+
+            // Use current patch as fallback if no security patches exist yet
+            var latestSecurityVersion = latestSecurityPatch?.PatchVersion ?? latestPatch.PatchVersion;
+            var latestSecurityDateOnly = latestSecurityPatch?.ReleaseDate ?? latestPatch.ReleaseDate;
+            var latestSecurityDate = new DateTimeOffset(latestSecurityDateOnly, TimeOnly.MinValue, TimeSpan.Zero);
+
+            var patchEntry = new LlmsPatchEntry(
+                latestPatch.PatchVersion,
+                summary.Lifecycle.ReleaseType.Value,
+                cveIds?.Count > 0,
+                summary.Lifecycle.Phase,
+                summary.Lifecycle.Supported,
+                sdkVersion,
+                latestSecurityVersion,
+                latestSecurityDate,
+                HalHelpers.OrderLinks(patchLinks));
+
+            latestPatches[summary.MajorVersion] = patchEntry;
+        }
+
+        // Find latest month and latest security month for links
+        string? latestMonthYear = null;
+        string? latestMonthNumber = null;
+        string? latestSecurityMonthYear = null;
+        string? latestSecurityMonthNumber = null;
+
+        var allMonths = releaseHistory.Years
+            .SelectMany(y => y.Value.Months.Select(m => (Year: y.Key, Month: m.Key, Data: m.Value)))
+            .OrderByDescending(m => m.Year)
+            .ThenByDescending(m => m.Month)
+            .ToList();
+
+        // First entry is the latest month
+        if (allMonths.Count > 0)
+        {
+            latestMonthYear = allMonths[0].Year;
+            latestMonthNumber = allMonths[0].Month;
+        }
+
+        foreach (var (yearKey, monthKey, monthData) in allMonths)
+        {
+            // Check if this month has any CVEs
+            var hasCves = monthData.Days.Values
+                .SelectMany(d => d.Releases)
+                .Any(r => r.CveList?.Count > 0);
+
+            if (hasCves)
+            {
+                latestSecurityMonthYear = yearKey;
+                latestSecurityMonthNumber = monthKey;
+                break;
+            }
+        }
+
+        // Compute latest patch date and latest security patch date from embedded patches
+        DateTimeOffset? latestPatchDate = null;
+        DateTimeOffset? latestSecurityPatchDate = null;
+
+        foreach (var summary in supportedSummaries)
+        {
+            var latestPatch = summary.PatchReleases
+                .OrderByDescending(p => p.ReleaseDate)
+                .ThenByDescending(p => p.PatchVersion, numericStringComparer)
+                .FirstOrDefault();
+
+            if (latestPatch != null)
+            {
+                var patchDate = new DateTimeOffset(latestPatch.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero);
+                if (latestPatchDate == null || patchDate > latestPatchDate)
+                {
+                    latestPatchDate = patchDate;
+                }
+            }
+
+            var latestSecurityPatch = summary.PatchReleases
+                .Where(p => p.CveList?.Count > 0)
+                .OrderByDescending(p => p.ReleaseDate)
+                .ThenByDescending(p => p.PatchVersion, numericStringComparer)
+                .FirstOrDefault();
+
+            if (latestSecurityPatch != null)
+            {
+                var securityPatchDate = new DateTimeOffset(latestSecurityPatch.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero);
+                if (latestSecurityPatchDate == null || securityPatchDate > latestSecurityPatchDate)
+                {
+                    latestSecurityPatchDate = securityPatchDate;
+                }
+            }
+        }
+
+        // Build root links
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Llms}")
+        };
+
+        // Add latest links
+        if (latestVersion != null)
+        {
+            links[LinkRelations.LatestMajor] = new HalLink($"{Location.GitHubBaseUri}{latestVersion}/{FileNames.Index}")
+            {
+                Title = $"Latest major release - .NET {latestVersion}"
+            };
+        }
+
+        if (latestLtsVersion != null)
+        {
+            links[LinkRelations.LatestLtsMajor] = new HalLink($"{Location.GitHubBaseUri}{latestLtsVersion}/{FileNames.Index}")
+            {
+                Title = $"Latest LTS major release - .NET {latestLtsVersion}"
+            };
+        }
+
+        if (latestYear != null)
+        {
+            links[LinkRelations.LatestYear] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestYear}/{FileNames.Index}")
+            {
+                Title = $"Latest year - {latestYear}"
+            };
+        }
+
+        // Add latest-month link
+        if (latestMonthYear != null && latestMonthNumber != null)
+        {
+            links[LinkRelations.LatestMonth] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestMonthYear}/{latestMonthNumber}/{FileNames.Index}")
+            {
+                Title = $"Latest month - {IndexTitles.FormatMonthYear(latestMonthYear, latestMonthNumber)}"
+            };
+        }
+
+        // Add latest-security-month link
+        if (latestSecurityMonthYear != null && latestSecurityMonthNumber != null)
+        {
+            links[LinkRelations.LatestSecurityMonth] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestSecurityMonthYear}/{latestSecurityMonthNumber}/{FileNames.Index}")
+            {
+                Title = $"Latest security month - {IndexTitles.FormatMonthYear(latestSecurityMonthYear, latestSecurityMonthNumber)}"
+            };
+
+            // Add latest-cve-json link (direct access to CVE data)
+            links[LinkRelations.LatestCveJson] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestSecurityMonthYear}/{latestSecurityMonthNumber}/{FileNames.Cve}")
+            {
+                Title = $"Latest CVE records - {IndexTitles.FormatMonthYear(latestSecurityMonthYear, latestSecurityMonthNumber)}",
+                Type = MediaType.Json
+            };
+
+            // Add latest-security-disclosures as semantic alias
+            links[LinkRelations.LatestSecurityDisclosures] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestSecurityMonthYear}/{latestSecurityMonthNumber}/{FileNames.Index}")
+            {
+                Title = $"Latest security disclosures - {IndexTitles.FormatMonthYear(latestSecurityMonthYear, latestSecurityMonthNumber)}"
+            };
+        }
+
+        // Add releases-index and timeline-index links
+        links[LinkRelations.Root] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Index}")
+        {
+            Title = ".NET Release Index"
+        };
+
+        links[LinkRelations.Timeline] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{FileNames.Index}")
+        {
+            Title = ".NET Release Timeline Index"
+        };
+
+        // Build required_pre_read URL (skill file in release-notes/)
+        var requiredPreRead = $"{Location.GitHubBaseUri}skills/dotnet-releases/SKILL.md";
+
+        // Merge additional links from partial
+        if (partial?.Links != null)
+        {
+            foreach (var (key, link) in partial.Links)
+            {
+                if (key == HalTerms.Self) continue;
+                links[key] = link;
+            }
+        }
+
+        // Build the LlmsIndex
+        var llmsIndex = new LlmsIndexRecord(
+            ReleaseKind.Llms,
+            partial?.Title ?? ".NET Release Index for AI")
+        {
+            AiNote = partial?.AiNote ?? "ALWAYS read required_pre_read first. HAL graph—follow _links only, never construct URLs.",
+            RequiredPreRead = requiredPreRead,
+            LatestMajor = latestVersion,
+            LatestLtsMajor = latestLtsVersion,
+            LatestPatchDate = latestPatchDate,
+            LatestSecurityPatchDate = latestSecurityPatchDate,
+            LastUpdatedDate = DateTimeOffset.UtcNow,
+            SupportedMajorReleases = supportedReleases,
+            Links = HalHelpers.OrderLinks(links),
+            Embedded = new LlmsIndexEmbedded
+            {
+                Patches = latestPatches.Count > 0 ? latestPatches : null
+            }
+        };
+
+        // Serialize
+        var llmsIndexJson = JsonSerializer.Serialize(
+            llmsIndex,
+            LlmsIndexSerializerContext.Default.LlmsIndex);
+
+        // Write to file
+        var llmsIndexPath = Path.Combine(outputDir, FileNames.Llms);
+        var finalJson = llmsIndexJson + '\n';
+        await File.WriteAllTextAsync(llmsIndexPath, finalJson);
+
+        Console.WriteLine($"Generated {llmsIndexPath}");
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/ManifestGenerator.cs
+++ b/src/Dotnet.Release.IndexGenerator/ManifestGenerator.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public static class ManifestGenerator
+{
+    public static async Task<ReleaseManifest> GenerateManifestAsync(string majorVersionDir, string version, VersionIndexHalLinkGenerator halLinkGenerator)
+    {
+        var versionLabel = $".NET {version}";
+
+        // Read partial manifest (_manifest.json is now schema-compatible with manifest.json)
+        var partialManifestPath = Path.Combine(majorVersionDir, FileNames.PartialManifest);
+        PartialManifest? partial = null;
+
+        if (File.Exists(partialManifestPath))
+        {
+            try
+            {
+                var partialJson = await File.ReadAllTextAsync(partialManifestPath);
+                partial = JsonSerializer.Deserialize<PartialManifest>(partialJson, ReleaseManifestSerializerContext.Default.PartialManifest);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Failed to read {partialManifestPath}: {ex.Message}");
+            }
+        }
+
+        // Use values from _manifest.json with computed fallbacks
+        var targetFramework = partial?.TargetFramework;
+        if (targetFramework == null)
+        {
+            Console.WriteLine($"Warning: {version} - Missing target_framework in _manifest.json");
+        }
+        var releaseType = partial?.ReleaseType ?? (IsEvenMajorVersion(version) ? ReleaseType.LTS : ReleaseType.STS);
+        var phase = partial?.SupportPhase ?? SupportPhase.Preview;
+        var gaDate = partial?.GaDate;
+        var eolDate = partial?.EolDate;
+
+        // Compute effective phase and supported flag
+        bool? supported = null;
+        if (gaDate.HasValue && eolDate.HasValue)
+        {
+            phase = ReleaseStability.ComputeEffectivePhase(phase, gaDate.Value);
+            var lifecycle = new Lifecycle(releaseType, phase, gaDate.Value, eolDate.Value);
+            supported = ReleaseStability.IsSupported(lifecycle);
+        }
+        else
+        {
+            Console.WriteLine($"Warning: {version} - Missing ga_date or eol_date in _manifest.json");
+        }
+
+        // Generate self link for manifest (href only)
+        var manifestPath = $"{version}/{FileNames.Manifest}";
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{manifestPath}")
+        };
+
+        // Generate operational/reference links from ManifestFileMappings
+        // Keep titles simple within manifest - version context is already established
+        var operationalLinks = halLinkGenerator.Generate(
+            majorVersionDir,
+            ReleaseIndexFiles.ManifestFileMappings.Values,
+            (fileLink, key) => fileLink.Title,
+            includeSelf: false);
+
+        // Add operational links
+        foreach (var (key, link) in operationalLinks)
+        {
+            links[key] = link;
+        }
+
+        // Merge in additional links from partial manifest (skip self - we generate it)
+        if (partial?.Links != null)
+        {
+            foreach (var (key, link) in partial.Links)
+            {
+                if (key == HalTerms.Self)
+                    continue;
+                links[key] = link;
+            }
+        }
+
+        // Create the final manifest with computed values
+        return new ReleaseManifest(
+            partial?.Kind ?? ReleaseKind.Manifest,
+            partial?.Title ?? $"{versionLabel} Manifest",
+            partial?.Version ?? version,
+            partial?.Label ?? versionLabel)
+        {
+            TargetFramework = targetFramework,
+            ReleaseType = releaseType,
+            SupportPhase = phase,
+            Supported = supported,
+            GaDate = gaDate,
+            EolDate = eolDate,
+            Links = HalHelpers.OrderLinks(links)
+        };
+    }
+
+    private static bool IsEvenMajorVersion(string version)
+    {
+        if (version.Contains('.'))
+        {
+            var majorPart = version.Split('.')[0];
+            if (int.TryParse(majorPart, out int major))
+            {
+                return major % 2 == 0;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/PathContext.cs
+++ b/src/Dotnet.Release.IndexGenerator/PathContext.cs
@@ -1,0 +1,3 @@
+namespace Dotnet.Release.IndexGenerator;
+
+public record PathContext(string Basepath, string? UrlBasePath = null);

--- a/src/Dotnet.Release.IndexGenerator/Records.cs
+++ b/src/Dotnet.Release.IndexGenerator/Records.cs
@@ -1,0 +1,17 @@
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public record ReleaseKindMapping(string Name, string Filename, ReleaseKind Kind, string FileType);
+
+public record FileLink(string File, string Title, LinkStyle Style);
+
+public record HalTuple(string Key, ReleaseKind Kind, HalLink Link);
+
+[Flags]
+public enum LinkStyle
+{
+    Prod = 1 << 0,
+    GitHub = 1 << 1,
+}

--- a/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
@@ -1,0 +1,1091 @@
+using System.Globalization;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Summary;
+using Dotnet.Release.CveHandler;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class ReleaseIndexFiles
+{
+    public static readonly OrderedDictionary<string, FileLink> MainFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.DotNetReleaseIndex, LinkStyle.Prod) },
+        {$"{FileNames.Directories.Timeline}/{FileNames.Index}", new FileLink($"{FileNames.Directories.Timeline}/{FileNames.Index}", IndexTitles.TimelineIndexLink, LinkStyle.Prod) },
+    };
+
+    // Links for major version index - lean navigation hub
+    public static readonly OrderedDictionary<string, FileLink> MajorVersionFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.Index, LinkStyle.Prod) },
+        {FileNames.Manifest, new FileLink(FileNames.Manifest, LinkTitles.ReleaseManifest, LinkStyle.Prod) },
+    };
+
+    // Links for manifest.json - operational/reference links
+    public static readonly OrderedDictionary<string, FileLink> ManifestFileMappings = new()
+    {
+        {FileNames.Compatibility, new FileLink(FileNames.Compatibility, LinkTitles.Compatibility, LinkStyle.Prod) },
+        {FileNames.TargetFrameworks, new FileLink(FileNames.TargetFrameworks, LinkTitles.TargetFrameworks, LinkStyle.Prod) },
+        {FileNames.SupportedOs, new FileLink(FileNames.SupportedOs, LinkTitles.SupportedOSes, LinkStyle.Prod) },
+        {FileNames.OsPackages, new FileLink(FileNames.OsPackages, LinkTitles.OsPackages, LinkStyle.Prod) },
+        {"linux-packages.json", new FileLink("linux-packages.json", LinkTitles.LinuxPackages, LinkStyle.Prod) },
+        {"supported-os.md", new FileLink("supported-os.md", LinkTitles.SupportedOSes, LinkStyle.Prod | LinkStyle.GitHub) },
+        {"linux-packages.md", new FileLink("linux-packages.md", LinkTitles.LinuxPackages, LinkStyle.Prod | LinkStyle.GitHub) },
+        {"README.md", new FileLink("README.md", LinkTitles.ReleaseNotes, LinkStyle.GitHub) }
+    };
+
+    private readonly List<string> _leafFiles = [FileNames.Releases, FileNames.Release, FileNames.Manifest];
+
+    private static bool IsVersionSdkSupported(string version)
+    {
+        // SDK hive is only supported for .NET 8.0 and later
+        if (string.IsNullOrEmpty(version) || !version.Contains('.'))
+        {
+            return false;
+        }
+
+        var parts = version.Split('.');
+        if (parts.Length < 2 || !int.TryParse(parts[0], out var major))
+        {
+            return false;
+        }
+
+        return major >= 8;
+    }
+
+    // Generates index files for each major version directory and one root index file
+    public static async Task GenerateAsync(List<MajorReleaseSummary> summaries, string inputDir, string outputDir)
+    {
+        if (!Directory.Exists(inputDir))
+        {
+            throw new DirectoryNotFoundException($"Input directory does not exist: {inputDir}");
+        }
+
+        if (!Directory.Exists(outputDir))
+        {
+            Directory.CreateDirectory(outputDir);
+        }
+
+        var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+        List<MajorReleaseVersionIndexEntry> majorEntries = [];
+
+        var summaryTable = summaries.ToDictionary(
+            s => s.MajorVersion,
+            s => s,
+            StringComparer.OrdinalIgnoreCase);
+
+        var urlGenerator = (string relativePath, LinkStyle style) => style == LinkStyle.Prod
+            ? $"{Location.GitHubBaseUri}{relativePath}"
+            : $"https://github.com/dotnet/core/blob/main/release-notes/{relativePath}";
+
+        var halLinkGenerator = new VersionIndexHalLinkGenerator(inputDir, urlGenerator);
+
+        // Look at all the major version directories
+        // The presence of a releases.json file indicates this is a major version directory
+        foreach (var majorVersionDir in Directory.EnumerateDirectories(inputDir))
+        {
+            var majorVersionDirName = Path.GetFileName(majorVersionDir);
+
+            if (!summaryTable.TryGetValue(majorVersionDirName, out var summary))
+            {
+                continue;
+            }
+
+            // Generate manifest.json from _manifest.json and computed data
+            var generatedManifest = await ManifestGenerator.GenerateManifestAsync(majorVersionDir, majorVersionDirName, halLinkGenerator);
+
+            // Write the generated manifest.json
+            var outputMajorVersionDir = Path.Combine(outputDir, majorVersionDirName);
+            if (!Directory.Exists(outputMajorVersionDir))
+            {
+                Directory.CreateDirectory(outputMajorVersionDir);
+            }
+            var manifestPath = Path.Combine(outputMajorVersionDir, FileNames.Manifest);
+            var manifestJson = JsonSerializer.Serialize(
+                generatedManifest,
+                ReleaseManifestSerializerContext.Default.ReleaseManifest);
+            await File.WriteAllTextAsync(manifestPath, manifestJson);
+
+            // Use lifecycle from summary (canonical source from ReleaseSummaryLoader)
+            var lifecycle = summary.Lifecycle;
+
+            // Generate base links for major version index (lean navigation hub)
+            var majorVersionLinks = halLinkGenerator.Generate(
+                majorVersionDir,
+                MajorVersionFileMappings.Values,
+                (fileLink, key) => key switch
+                {
+                    HalTerms.Self => summary.MajorVersionLabel,
+                    LinkRelations.Manifest => $"Manifest - .NET {majorVersionDirName}",
+                    _ => fileLink.Title
+                });
+
+            // Generate patch version index; release-notes/8.0/index.json
+            var patchEntries = await GetPatchIndexEntriesAsync(summaryTable[majorVersionDirName].PatchReleases, new PathContext(majorVersionDir, inputDir), lifecycle, outputDir, majorVersionDirName);
+
+            // Determine latest and latest-security
+            // Patches are ordered latest first, so first entry is latest
+            var latestPatch = patchEntries.FirstOrDefault();
+
+            // Get the latest patch version for the description (use latestPatch which handles semver correctly)
+            var latestPatchVersion = latestPatch?.Version ?? summary.PatchReleases.Select(p => p.PatchVersion).Max(numericStringComparer);
+            var patchDescription = $".NET {majorVersionDirName} (latest: {latestPatchVersion})";
+            var latestSecurityPatch = patchEntries.FirstOrDefault(e => e.CveRecords?.Count > 0);
+
+            // Get latest patch directory path for release.json link
+            var latestPatchSummary = summary.PatchReleases.FirstOrDefault(p => p.PatchVersion == latestPatchVersion);
+
+            // Build ordered links for major version index (lean navigation hub)
+            var orderedMajorVersionLinks = new Dictionary<string, HalLink>();
+
+            // 1. Add HAL+JSON links from base mappings first (Type is null for HAL+JSON)
+            // Strip title from self link (href is sufficient)
+            foreach (var link in majorVersionLinks.Where(kvp => kvp.Value.Type == null))
+            {
+                orderedMajorVersionLinks[link.Key] = link.Key == HalTerms.Self
+                    ? new HalLink(link.Value.Href)
+                    : link.Value;
+            }
+
+            // 2. Add SDK links for supported versions (8.0+) - these are HAL+JSON
+            if (IsVersionSdkSupported(majorVersionDirName))
+            {
+                // Add downloads link to downloads directory
+                var downloadsIndexPath = $"{majorVersionDirName}/{FileNames.Directories.Downloads}/{FileNames.Index}";
+                orderedMajorVersionLinks[LinkRelations.Downloads] = new HalLink($"{Location.GitHubBaseUri}{downloadsIndexPath}")
+                {
+                    Title = $"Downloads - .NET {majorVersionDirName}",
+                };
+            }
+
+            // 2b. Add releases-index link (one level up to root index)
+            orderedMajorVersionLinks[LinkRelations.Root] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Index}")
+            {
+                Title = LinkTitles.DotNetReleaseIndex,
+            };
+
+            // 3. Add latest and latest-security HAL+JSON links
+            if (latestPatch != null)
+            {
+                var latestPatchIndexPath = $"{majorVersionDirName}/{latestPatch.Version}/{FileNames.Index}";
+                orderedMajorVersionLinks[LinkRelations.LatestPatch] = new HalLink($"{Location.GitHubBaseUri}{latestPatchIndexPath}")
+                {
+                    Title = $"Latest patch - {latestPatch.Version}",
+                };
+
+                // Add latest-month link to timeline month for the latest patch
+                if (latestPatch.Lifecycle?.GaDate != null)
+                {
+                    var patchDate = latestPatch.Lifecycle.GaDate;
+                    var patchYear = patchDate.Year.ToString("D4");
+                    var patchMonth = patchDate.Month.ToString("D2");
+                    orderedMajorVersionLinks[LinkRelations.LatestMonth] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{patchYear}/{patchMonth}/{FileNames.Index}")
+                    {
+                        Title = $"Latest month - {IndexTitles.FormatMonthYear(patchYear, patchMonth)}",
+                    };
+                }
+            }
+
+            if (latestSecurityPatch != null)
+            {
+                var latestSecurityPatchIndexPath = $"{majorVersionDirName}/{latestSecurityPatch.Version}/{FileNames.Index}";
+                orderedMajorVersionLinks[LinkRelations.LatestSecurityPatch] = new HalLink($"{Location.GitHubBaseUri}{latestSecurityPatchIndexPath}")
+                {
+                    Title = $"Latest security patch - {latestSecurityPatch.Version}",
+                };
+
+                // Add latest-security-month and latest-cve-json links
+                if (latestSecurityPatch.Lifecycle?.GaDate != null)
+                {
+                    var securityPatchDate = latestSecurityPatch.Lifecycle.GaDate;
+                    var securityYear = securityPatchDate.Year.ToString("D4");
+                    var securityMonth = securityPatchDate.Month.ToString("D2");
+
+                    orderedMajorVersionLinks[LinkRelations.LatestSecurityMonth] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{securityYear}/{securityMonth}/{FileNames.Index}")
+                    {
+                        Title = $"Latest security month - {IndexTitles.FormatMonthYear(securityYear, securityMonth)}",
+                    };
+
+                    // Add latest-security-disclosures as semantic alias
+                    orderedMajorVersionLinks[LinkRelations.LatestSecurityDisclosures] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{securityYear}/{securityMonth}/{FileNames.Index}")
+                    {
+                        Title = $"Latest security disclosures - {IndexTitles.FormatMonthYear(securityYear, securityMonth)}",
+                    };
+
+                    // Add latest-cve-json link for direct access to CVE data (only if cve.json exists)
+                    var cveJsonPath = Path.Combine(inputDir, FileNames.Directories.Timeline, securityYear, securityMonth, FileNames.Cve);
+                    if (File.Exists(cveJsonPath))
+                    {
+                        orderedMajorVersionLinks[LinkRelations.LatestCveJson] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{securityYear}/{securityMonth}/{FileNames.Cve}")
+                        {
+                            Title = $"Latest CVE records - {IndexTitles.FormatMonthYear(securityYear, securityMonth)}",
+                            Type = MediaType.Json
+                        };
+                    }
+                }
+            }
+
+            majorVersionLinks = orderedMajorVersionLinks;
+
+            // Generate SDK feature band entries
+            List<SdkFeatureBandEntry>? sdkFeatureBandEntries = null;
+            if (summary.SdkBands?.Count > 0)
+            {
+                sdkFeatureBandEntries = summary.SdkBands
+                    .OrderByDescending(b => b.Version, numericStringComparer)
+                    .Select(sdkBand =>
+                    {
+                        var bandVersion = sdkBand.Version[..5] + "xx"; // e.g., "8.0.4xx"
+
+                        // Find the latest SDK version in this feature band
+                        var latestInBand = summary.PatchReleases
+                            .SelectMany(p => p.Components
+                                .Where(c => c.Name.Equals("sdk", StringComparison.OrdinalIgnoreCase) &&
+                                           c.Version.StartsWith(sdkBand.Version[..5]))
+                                .Select(c => (Component: c, PatchRelease: p)))
+                            .OrderByDescending(x => x.Component.Version, numericStringComparer)
+                            .FirstOrDefault();
+
+                        var latestSdkInBand = latestInBand.Component?.Version;
+                        var latestPatchRelease = latestInBand.PatchRelease;
+
+                        // Build links for this feature band
+                        // Note: No titles or types in _embedded links - context established by parent
+                        var bandLinks = new Dictionary<string, HalLink>
+                        {
+                            ["downloads"] = new HalLink($"{Location.GitHubBaseUri}{majorVersionDirName}/{FileNames.Directories.Downloads}/sdk-{bandVersion}.json")
+                        };
+
+                        // Add patch link (to the patch release this SDK is part of)
+                        if (latestPatchRelease?.PatchDirPath != null)
+                        {
+                            var patchIndexPath = $"{latestPatchRelease.PatchDirPath}/{FileNames.Index}";
+                            bandLinks[LinkRelations.Patch] = new HalLink($"{Location.GitHubBaseUri}{patchIndexPath}");
+                        }
+
+                        // Add month link
+                        if (latestPatchRelease != null)
+                        {
+                            var year = latestPatchRelease.ReleaseDate.Year.ToString("D4");
+                            var month = latestPatchRelease.ReleaseDate.Month.ToString("D2");
+                            var monthIndexPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Index}";
+                            bandLinks[LinkRelations.Month] = new HalLink($"{Location.GitHubBaseUri}{monthIndexPath}");
+                        }
+
+                        return new SdkFeatureBandEntry(
+                            latestSdkInBand ?? bandVersion,  // version (latest SDK in band)
+                            bandVersion,                      // band (e.g., "9.0.3xx")
+                            latestPatchRelease != null
+                                ? new DateTimeOffset(latestPatchRelease.ReleaseDate.ToDateTime(TimeOnly.MinValue), TimeSpan.FromHours(-8))
+                                : null,
+                            $".NET SDK {bandVersion}",
+                            sdkBand.SupportPhase,
+                            HalHelpers.OrderLinks(bandLinks));
+                    })
+                    .ToList();
+            }
+
+            // write major version index.json if there are patch releases found
+            var majorIndexPath = Path.Combine(outputMajorVersionDir, FileNames.Index);
+            var relativeMajorIndexPath = Path.GetRelativePath(inputDir, Path.Combine(majorVersionDir, FileNames.Index));
+
+            var patchVersionIndex = new PatchReleaseVersionIndex(
+                ReleaseKind.Major,
+                $".NET Major Release Index - {summary.MajorVersionLabel.Replace(".NET ", string.Empty)}")
+            {
+                TargetFramework = generatedManifest.TargetFramework,
+                LatestPatch = latestPatch?.Version,
+                LatestPatchDate = latestPatch?.Lifecycle?.GaDate,
+                LatestSecurityPatch = latestSecurityPatch?.Version,
+                LatestSecurityPatchDate = latestSecurityPatch?.Lifecycle?.GaDate,
+                ReleaseType = lifecycle?.ReleaseType,
+                SupportPhase = lifecycle?.Phase,
+                Supported = lifecycle?.Supported,
+                GaDate = lifecycle?.GaDate,
+                EolDate = lifecycle?.EolDate,
+                Links = HalHelpers.OrderLinks(majorVersionLinks),
+                Embedded = patchEntries.Count > 0 ? new PatchReleaseVersionIndexEmbedded(
+                    patchEntries
+                    .Where(e => e.Lifecycle?.GaDate != null && e.Lifecycle?.Phase != null)
+                    .Select(e => {
+                        var gaDate = e.Lifecycle!.GaDate;
+                        var phase = e.Lifecycle!.Phase;
+                        var year = gaDate.Year.ToString("D4");
+                        var month = gaDate.Month.ToString("D2");
+
+                        // Build links - start with existing links
+                        var links = new Dictionary<string, HalLink>(e.Links);
+
+                        // Add month link for timeline navigation
+                        // Note: No titles in _embedded links - context established by parent
+                        var monthIndexPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Index}";
+                        links[LinkRelations.Month] = new HalLink($"{Location.GitHubBaseUri}{monthIndexPath}");
+
+                        // Add cve-json and security-disclosures links for security patches
+                        if (e.CveRecords?.Count > 0)
+                        {
+                            var cveJsonPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Cve}";
+                            links[LinkRelations.CveJson] = new HalLink($"{Location.GitHubBaseUri}{cveJsonPath}")
+                            {
+                                Type = MediaType.Json
+                            };
+
+                            // Add security-disclosures as semantic alias to month index
+                            links[LinkRelations.SecurityDisclosures] = new HalLink($"{Location.GitHubBaseUri}{monthIndexPath}");
+                        }
+
+                        // Note: CVE IDs (cve_records) are intentionally omitted from patch entries.
+                        // CVEs are a timeline concept - use month or cve-json link.
+                        return new PatchReleaseVersionIndexEntry(
+                            e.Version,
+                            gaDate,
+                            year,
+                            month,
+                            e.CveRecords?.Count > 0,
+                            phase)
+                        {
+                            SdkVersion = e.SdkVersions?.FirstOrDefault(),
+                            Links = HalHelpers.OrderLinks(links)
+                        };
+                    }).ToList())
+                {
+                    SdkFeatureBands = sdkFeatureBandEntries
+                } : null
+            };
+
+            // Serialize to string first to add schema reference
+            var patchIndexJson = JsonSerializer.Serialize(
+                patchVersionIndex,
+                ReleaseVersionIndexSerializerContext.Default.PatchReleaseVersionIndex);
+
+            // Add schema reference
+            var schemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.ReleaseVersionIndex}";
+            var updatedPatchIndexJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(patchIndexJson, schemaUri);
+
+            // Write to file
+            var patchIndexPath = Path.Combine(outputMajorVersionDir, FileNames.Index);
+            var finalPatchIndexJson = (updatedPatchIndexJson ?? patchIndexJson) + '\n';
+            await File.WriteAllTextAsync(patchIndexPath, finalPatchIndexJson);
+
+            // Same links as the major version index, but with a different base directory (to force different pathing)
+            // NOTE: Do NOT add latest-patch or latest-month links here - those change monthly
+            // and would cause the root index.json to change frequently. Those links belong
+            // in the major version indexes (e.g., 8.0/index.json) instead.
+            var majorVersionWithinAllReleasesIndexLinks = halLinkGenerator.Generate(
+                majorVersionDir,
+                MainFileMappings.Values,
+                (fileLink, key) => key switch
+                {
+                    HalTerms.Self => summary.MajorVersionLabel,
+                    LinkRelations.Manifest => $"Manifest - .NET {majorVersionDirName}",
+                    _ => fileLink.Title
+                });
+
+            // Major version entries use minimal lifecycle properties for root index stability.
+            // Omitted properties (available in major version indexes like 8.0/index.json):
+            // - Phase: changes frequently (preview->go-live->active->maintenance)
+            // - GaDate/EolDate: static, fetch from referenced resource
+            // - Years: changes every January for active releases
+            // - Path/Title in self links: redundant with href, keeps entries lean
+            // Root index focuses on: release_type, supported (for quick filtering)
+
+            // Strip title and type from self links for root index entries (href is sufficient)
+            var minimalLinks = majorVersionWithinAllReleasesIndexLinks.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Key == HalTerms.Self
+                    ? new HalLink(kvp.Value.Href)  // Self link: href only
+                    : new HalLink(kvp.Value.Href) { Title = kvp.Value.Title, Type = kvp.Value.Type });
+
+            var majorEntry = new MajorReleaseVersionIndexEntry(majorVersionDirName)
+            {
+                ReleaseType = lifecycle?.ReleaseType,
+                Supported = lifecycle?.Supported,
+                Links = HalHelpers.OrderLinks(minimalLinks)
+            };
+
+            majorEntries.Add(majorEntry);
+        }
+
+        // Generate base links from MainFileMappings first
+        var rootLinks = halLinkGenerator.Generate(
+            inputDir,
+            MainFileMappings.Values,
+            (fileLink, key) => key == HalTerms.Self ? IndexTitles.VersionIndexLink : fileLink.Title);
+
+        // Find latest stable release and latest LTS release (used for both links and properties)
+        MajorReleaseVersionIndexEntry? latestRelease = null;
+        MajorReleaseVersionIndexEntry? latestLtsRelease = null;
+
+        // Insert dynamic HAL+JSON links after release-history-index but before markdown files
+        if (majorEntries.Count > 0)
+        {
+            // Create a new ordered dictionary to maintain proper ordering
+            var orderedRootLinks = new Dictionary<string, HalLink>();
+
+            // Add HAL+JSON links first (Type is null for HAL+JSON)
+            foreach (var link in rootLinks.Where(kvp => kvp.Value.Type == null))
+            {
+                orderedRootLinks[link.Key] = link.Value;
+            }
+
+            // Find latest stable and supported release
+            // Uses shared ReleaseStability methods to ensure consistent logic across tools
+            var releaseData = summaries.Select(s => (s.MajorVersion, (Lifecycle?)s.Lifecycle));
+            var latestVersion = ReleaseStability.FindLatestVersion(releaseData, numericStringComparer);
+            var latestLtsVersion = ReleaseStability.FindLatestLtsVersion(releaseData, numericStringComparer);
+
+            latestRelease = latestVersion != null
+                ? majorEntries.FirstOrDefault(e => e.Version == latestVersion)
+                : null;
+
+            if (latestRelease != null)
+            {
+                orderedRootLinks[LinkRelations.LatestMajor] = new HalLink($"{Location.GitHubBaseUri}{latestRelease.Version}/{FileNames.Index}")
+                {
+                    Title = $"Latest major release - .NET {latestRelease.Version}",
+                };
+            }
+
+            // Find latest stable LTS release (uses lifecycle.ReleaseType, not version number heuristics)
+            latestLtsRelease = latestLtsVersion != null
+                ? majorEntries.FirstOrDefault(e => e.Version == latestLtsVersion)
+                : null;
+
+            if (latestLtsRelease != null)
+            {
+                orderedRootLinks[LinkRelations.LatestLtsMajor] = new HalLink($"{Location.GitHubBaseUri}{latestLtsRelease.Version}/{FileNames.Index}")
+                {
+                    Title = $"Latest LTS major release - .NET {latestLtsRelease.Version}",
+                };
+            }
+
+            // NOTE: Do NOT add latest-year link here - it changes every January
+            // and would cause the root index.json to change annually. The timeline-index
+            // link provides access to the timeline, which has its own latest-year link.
+
+            // Add non-HAL+JSON links (markdown files) after
+            foreach (var link in rootLinks.Where(kvp => kvp.Value.Type != MediaType.HalJson))
+            {
+                orderedRootLinks[link.Key] = link.Value;
+            }
+
+            rootLinks = orderedRootLinks;
+        }
+
+        Console.WriteLine($"Found {rootLinks.Count} root links in {inputDir}");
+
+        // Create the major releases index; release-notes/index.json
+        var rootIndexPath = Path.Combine(outputDir, FileNames.Index);
+
+        // NOTE: Do NOT include LatestYear property - it changes every January
+        // and would cause the root index.json to change annually. The timeline-index
+        // link provides access to timeline/index.json which has its own latest_year.
+        var majorIndex = new MajorReleaseVersionIndex(
+                ReleaseKind.Root,
+                IndexTitles.VersionIndexTitle)
+        {
+            LatestMajor = latestRelease?.Version,
+            LatestLtsMajor = latestLtsRelease?.Version,
+            Links = HalHelpers.OrderLinks(rootLinks),
+            Embedded = new MajorReleaseVersionIndexEmbedded
+            {
+                Releases = [.. majorEntries.OrderByDescending(e => e.Version, numericStringComparer)]
+            }
+        };
+
+        // Serialize to string first to add schema reference
+        var majorIndexJson = JsonSerializer.Serialize(
+            majorIndex,
+            ReleaseVersionIndexSerializerContext.Default.MajorReleaseVersionIndex);
+
+        // Add schema reference
+        var rootSchemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.ReleaseVersionIndex}";
+        var updatedMajorIndexJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(majorIndexJson, rootSchemaUri);
+
+        // Write the major index file
+        var rootMajorIndexPath = Path.Combine(outputDir, FileNames.Index);
+        var finalMajorIndexJson = (updatedMajorIndexJson ?? majorIndexJson) + '\n';
+        await File.WriteAllTextAsync(rootMajorIndexPath, finalMajorIndexJson);
+    }
+
+    // Generates index containing each patch release in the major version directory
+    private static async Task<List<ReleaseVersionIndexEntry>> GetPatchIndexEntriesAsync(
+        IList<PatchReleaseSummary> summaries,
+        PathContext pathContext,
+        Lifecycle? majorVersionLifecycle,
+        string outputDir,
+        string majorVersion)
+    {
+        var (rootDir, urlRootDir) = pathContext;
+
+        if (!Directory.Exists(rootDir))
+        {
+            throw new DirectoryNotFoundException($"Output directory does not exist: {rootDir}");
+        }
+
+        // Determine if this is a GA release (for filtering previews from index)
+        // RC releases are kept (they have go-live support), only previews are excluded from index
+        var isGaRelease = majorVersionLifecycle?.Phase is SupportPhase.Active or SupportPhase.Maintenance or SupportPhase.Eol;
+
+        var summaryTable = summaries.ToDictionary(
+            s => s.PatchVersion,
+            s => s,
+            StringComparer.OrdinalIgnoreCase);
+
+        List<ReleaseVersionIndexEntry> indexEntries = [];
+        var inputRoot = Path.GetDirectoryName(rootDir) ?? rootDir;
+
+        // Convert to list for index-based access (for prev/next navigation)
+        var summaryList = summaries.ToList();
+
+        for (int i = 0; i < summaryList.Count; i++)
+        {
+            var summary = summaryList[i];
+            if (!summaryTable.ContainsKey(summary.PatchVersion))
+            {
+                continue;
+            }
+
+            // Skip patches without a directory (required for index generation)
+            if (summary.PatchDirPath == null)
+            {
+                continue;
+            }
+
+            // PatchDirPath is relative to the input root (e.g., "10.0/10.0.0" or "10.0/preview/preview1")
+            // We need to construct the full path using the major version directory's parent
+            var patchDir = Path.Combine(inputRoot, summary.PatchDirPath);
+
+            // Create links - self now points to index.json (href only), with separate link to release.json
+            // Use PatchDirPath for the URL path (handles preview/rc structure)
+            var patchIndexPath = $"{summary.PatchDirPath}/{FileNames.Index}";
+            var links = new Dictionary<string, HalLink>
+                {
+                    { HalTerms.Self, new HalLink(VersionIndexHelpers.GetProdPath(patchIndexPath)) }
+                };
+
+            // Determine CVE IDs - prefer cve.json (authoritative), fall back to releases.json
+            IReadOnlyList<string>? cveIds = null;
+
+            // First, try to get CVE IDs from cve.json (authoritative source)
+            var releaseDate = summary.ReleaseDate;
+            var releaseDateOffset = new DateTimeOffset(releaseDate.Year, releaseDate.Month, releaseDate.Day, 0, 0, 0, TimeSpan.Zero);
+            var cveRecords = await CveLoader.LoadForReleaseDateAsync(inputRoot, releaseDateOffset);
+
+            if (cveRecords?.ReleaseCves != null && cveRecords.ReleaseCves.TryGetValue(majorVersion, out var cveIdsFromCveJson))
+            {
+                // Use cve.json as authoritative source - it correctly excludes package-only CVEs
+                cveIds = cveIdsFromCveJson.ToList();
+
+                // Log if there's a mismatch with releases.json (for awareness)
+                var cveIdsFromRelease = summary.CveList?.Select(cve => cve.CveId).ToList();
+                if (cveIdsFromRelease?.Count > 0)
+                {
+                    CveTransformer.ValidateCveData(
+                        summary.PatchVersion,
+                        cveIdsFromRelease,
+                        cveIds as IReadOnlyList<string>);
+                }
+            }
+            else if (summary.CveList?.Count > 0)
+            {
+                // Fall back to releases.json if cve.json not available
+                cveIds = summary.CveList.Select(cve => cve.CveId).ToList();
+            }
+
+            // Create simplified lifecycle for patch releases (per spec: only phase and release-date)
+            SupportPhase patchPhase;
+            DateTimeOffset patchReleaseDate;
+
+            // Use actual patch release date from summary
+            var releaseDateOnly = summary.ReleaseDate;
+            patchReleaseDate = new DateTimeOffset(releaseDateOnly.Year, releaseDateOnly.Month, releaseDateOnly.Day, 0, 0, 0, TimeSpan.Zero);
+
+            // Determine phase based on version string and release date
+            // This synthesizes the phase AT TIME OF RELEASE (patch indexes are immutable)
+            if (summary.PatchVersion.Contains("-preview."))
+            {
+                patchPhase = SupportPhase.Preview;
+            }
+            else if (summary.PatchVersion.Contains("-rc."))
+            {
+                patchPhase = SupportPhase.GoLive;
+            }
+            else if (majorVersionLifecycle != null)
+            {
+                // GA patches: determine if Active or Maintenance based on release date
+                // Maintenance phase starts 6 months before EOL
+                var maintenanceStart = majorVersionLifecycle.EolDate.AddMonths(-6);
+                if (patchReleaseDate >= maintenanceStart)
+                {
+                    patchPhase = SupportPhase.Maintenance;
+                }
+                else
+                {
+                    patchPhase = SupportPhase.Active;
+                }
+            }
+            else
+            {
+                // Fallback: GA patches without lifecycle data are Active
+                patchPhase = SupportPhase.Active;
+            }
+
+            var patchLifecycle = new PatchLifecycle(patchPhase, patchReleaseDate);
+
+            // Determine prev patch (within same major version)
+            // summaryList is ordered newest to oldest, so prev is i+1 (older)
+            // NOTE: No "next" - patch indexes are immutable; navigate via "latest" and walk backwards
+            var prevSummary = i + 1 < summaryList.Count ? summaryList[i + 1] : null;
+
+            // Find prev-security patch (previous patch with CVEs)
+            // Search from i+1 onwards to find the first patch with security fixes
+            PatchReleaseSummary? prevSecuritySummary = null;
+            for (int j = i + 1; j < summaryList.Count; j++)
+            {
+                var candidate = summaryList[j];
+                // Check if this patch had CVEs (via CveList from releases.json)
+                if (candidate.CveList?.Count > 0)
+                {
+                    prevSecuritySummary = candidate;
+                    break;
+                }
+            }
+
+            // Always generate patch detail index (for all patches, not just those with CVEs)
+            // Convert DateOnly to DateTimeOffset for prev dates
+            DateTimeOffset? prevPatchDate = prevSummary != null
+                ? new DateTimeOffset(prevSummary.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero)
+                : null;
+            DateTimeOffset? prevSecurityPatchDate = prevSecuritySummary != null
+                ? new DateTimeOffset(prevSecuritySummary.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero)
+                : null;
+
+            await GeneratePatchDetailIndexAsync(
+                patchDir,
+                outputDir,
+                urlRootDir ?? inputRoot,
+                majorVersion,
+                summary.PatchVersion,
+                summary.PatchDirPath,
+                patchLifecycle,
+                cveIds,
+                prevSummary?.PatchVersion,
+                prevSummary?.PatchDirPath,
+                prevPatchDate,
+                prevSecuritySummary?.PatchVersion,
+                prevSecuritySummary?.PatchDirPath,
+                prevSecurityPatchDate);
+
+            // Get SDK versions from components
+            var sdkVersions = summary.Components?
+                .Where(c => c.Name == "SDK")
+                .Select(c => c.Version)
+                .OrderByDescending(v => v, StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering))
+                .ToList();
+            if (sdkVersions?.Count == 0) sdkVersions = null;
+
+            // Only add to index if not a preview release (for GA versions)
+            // Previews are still generated (manifest/index files) but excluded from major version index
+            var isPreview = summary.PatchVersion.Contains("-preview.");
+            if (!isGaRelease || !isPreview)
+            {
+                var indexEntry = new ReleaseVersionIndexEntry(summary.PatchVersion, links)
+                {
+                    CveRecords = cveIds,
+                    Lifecycle = patchLifecycle,
+                    SdkVersions = sdkVersions
+                };
+                indexEntries.Add(indexEntry);
+            }
+        }
+
+        return indexEntries;
+    }
+
+    // Generates a patch index file for a specific patch release
+    private static async Task GeneratePatchDetailIndexAsync(
+        string patchDir,
+        string outputDir,
+        string inputDir,
+        string majorVersion,
+        string patchVersion,
+        string patchDirPath,  // The relative path like "10.0/10.0.0" or "10.0/preview/preview1"
+        PatchLifecycle lifecycle,
+        IReadOnlyList<string>? cveIds,
+        string? prevPatchVersion,
+        string? prevPatchDirPath,
+        DateTimeOffset? prevPatchDate,
+        string? prevSecurityPatchVersion,
+        string? prevSecurityPatchDirPath,
+        DateTimeOffset? prevSecurityPatchDate)
+    {
+        // Create patch detail index links - HAL+JSON links first, then JSON
+        var links = new Dictionary<string, HalLink>
+        {
+            // HAL+JSON links first - self link has no title (inferable)
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{FileNames.Index}"),
+            [LinkRelations.Major] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.Index}")
+            {
+                Title = $".NET Major Release Index - {majorVersion}",
+            }
+        };
+
+        // Add releases-index link (grandparent - root index)
+        links[LinkRelations.Root] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Index}")
+        {
+            Title = LinkTitles.DotNetReleaseIndex,
+        };
+
+        // Add downloads link if version supports SDK (8.0+)
+        if (IsVersionSdkSupported(majorVersion))
+        {
+            links[LinkRelations.Downloads] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.Directories.Downloads}/{FileNames.Index}")
+            {
+                Title = $"Downloads - .NET {majorVersion}",
+            };
+        }
+
+        // Add prev links for patch navigation within the same major version
+        if (prevPatchVersion != null && prevPatchDirPath != null)
+        {
+            links[LinkRelations.PrevPatch] = new HalLink($"{Location.GitHubBaseUri}{prevPatchDirPath}/{FileNames.Index}")
+            {
+                Title = $"Previous patch release - {prevPatchVersion}",
+            };
+        }
+
+        // Add prev-security-patch link for security patch navigation
+        if (prevSecurityPatchVersion != null && prevSecurityPatchDirPath != null)
+        {
+            links[LinkRelations.PrevSecurityPatch] = new HalLink($"{Location.GitHubBaseUri}{prevSecurityPatchDirPath}/{FileNames.Index}")
+            {
+                Title = $"Previous security patch release - {prevSecurityPatchVersion}",
+            };
+        }
+
+        // NOTE: No "next" links - patch indexes are immutable once created.
+        // Navigation pattern: start from "latest-patch" on major version index and walk backwards via "prev-patch" links.
+        // For security patches, start from "latest-security-patch" and walk backwards via "prev-security-patch" links.
+
+        // release-month will be added below after we determine the release date (HAL+JSON)
+
+        // Determine runtime release notes file (always {version}.md format)
+        var runtimeMdFileName = $"{patchVersion}.md";
+        var runtimeMdPath = Path.Combine(patchDir, runtimeMdFileName);
+        var runtimeMdExists = File.Exists(runtimeMdPath);
+
+        // Collect additional markdown files (component-specific release notes like aspnetcore.md, csharp.md, etc.)
+        var additionalMdFiles = Directory.GetFiles(patchDir, "*.md")
+            .Select(Path.GetFileName)
+            .Where(f => f != null &&
+                   !f.Equals(runtimeMdFileName, StringComparison.OrdinalIgnoreCase) &&
+                   !f.Equals("README.md", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Build runtime entry with release notes (downloads available via downloads relation)
+        RuntimeEntry? runtimeEntry = null;
+        Dictionary<string, HalLink>? documentation = null;
+        if (IsVersionSdkSupported(majorVersion))
+        {
+            var runtimeLinks = new Dictionary<string, HalLink>();
+
+            // Add runtime release notes if the file exists
+            if (runtimeMdExists)
+            {
+                runtimeLinks["release-notes"] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{runtimeMdFileName}")
+                {
+                    Type = MediaType.Markdown
+                };
+            }
+
+            // Build component-specific "what's new" links separately
+            foreach (var mdFile in additionalMdFiles)
+            {
+                var baseName = Path.GetFileNameWithoutExtension(mdFile)!;
+
+                // Skip version-specific files (e.g., 9.0.111.md) - those are SDK release notes
+                if (IsVersionString(baseName))
+                {
+                    continue;
+                }
+
+                // Component files (e.g., aspnetcore.md) -> aspnetcore key
+                documentation ??= new Dictionary<string, HalLink>();
+                documentation[baseName.ToLowerInvariant()] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{mdFile}")
+                {
+                    Type = MediaType.Markdown
+                };
+            }
+
+            if (runtimeLinks.Count > 0)
+            {
+                runtimeEntry = new RuntimeEntry(patchVersion, HalHelpers.OrderLinks(runtimeLinks));
+            }
+        }
+
+        // Load SDK versions from release.json and build SDK feature band entries
+        List<string>? sdkVersionsList = null;
+        List<SdkFeatureBandEntry>? sdkFeatureBandEntries = null;
+        string? highestSdkVersion = null;
+        var releaseJsonPath = Path.Combine(patchDir, FileNames.Release);
+
+        // Add release-json link if the file exists
+        if (File.Exists(releaseJsonPath))
+        {
+            links[LinkRelations.ReleaseJson] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{FileNames.Release}")
+            {
+                Title = "Release information",
+                Type = MediaType.Json
+            };
+        }
+
+        if (File.Exists(releaseJsonPath) && IsVersionSdkSupported(majorVersion))
+        {
+            try
+            {
+                var releaseJson = await File.ReadAllTextAsync(releaseJsonPath);
+                var releaseDoc = JsonDocument.Parse(releaseJson);
+
+                // Extract SDK versions - try release.sdks first, then fall back to sdks at root
+                var sdkVersions = new List<string>();
+                JsonElement? sdksElement = null;
+
+                if (releaseDoc.RootElement.TryGetProperty("release", out var releaseElement) &&
+                    releaseElement.TryGetProperty("sdks", out var nestedSdksElement))
+                {
+                    sdksElement = nestedSdksElement;
+                }
+                else if (releaseDoc.RootElement.TryGetProperty("sdks", out var rootSdksElement))
+                {
+                    sdksElement = rootSdksElement;
+                }
+
+                if (sdksElement.HasValue)
+                {
+                    foreach (var sdkElement in sdksElement.Value.EnumerateArray())
+                    {
+                        if (sdkElement.TryGetProperty("version", out var versionElement))
+                        {
+                            var version = versionElement.GetString();
+                            if (!string.IsNullOrEmpty(version))
+                            {
+                                sdkVersions.Add(version);
+                            }
+                        }
+                    }
+                }
+
+                if (sdkVersions.Count > 0)
+                {
+                    // Sort SDK versions descending to get highest first
+                    var numericComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+                    sdkVersions = sdkVersions.OrderByDescending(v => v, numericComparer).ToList();
+
+                    sdkVersionsList = sdkVersions;
+                    highestSdkVersion = sdkVersions.First();
+                    sdkFeatureBandEntries = [];
+
+                    // Build SDK feature band entries (same shape as sdk/index.json)
+                    foreach (var sdkVersion in sdkVersions)
+                    {
+                        var parts = sdkVersion.Split('.');
+                        if (parts.Length < 3) continue;
+
+                        var featureBand = $"{parts[0]}.{parts[1]}.{parts[2][0]}xx";
+
+                        // Build links for this feature band entry
+                        // Note: No titles or types in _embedded links - context established by parent
+                        // Note: release-month and release-patch omitted - available from parent patch index
+                        var bandLinks = new Dictionary<string, HalLink>
+                        {
+                            ["downloads"] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.Directories.Downloads}/sdk-{featureBand}.json")
+                        };
+
+                        // Add SDK release notes with fallback logic:
+                        // 1. Look for SDK-specific file (e.g., 9.0.111.md)
+                        // 2. Fall back to runtime release notes (e.g., 9.0.1.md) if not found
+                        var sdkMdFileName = $"{sdkVersion}.md";
+                        var sdkMdPath = Path.Combine(patchDir, sdkMdFileName);
+                        if (File.Exists(sdkMdPath))
+                        {
+                            bandLinks["release-notes"] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{sdkMdFileName}")
+                            {
+                                Type = MediaType.Markdown
+                            };
+                        }
+                        else if (runtimeMdExists)
+                        {
+                            // Fall back to runtime release notes
+                            bandLinks["release-notes"] = new HalLink($"{Location.GitHubBaseUri}{patchDirPath}/{runtimeMdFileName}")
+                            {
+                                Type = MediaType.Markdown
+                            };
+                        }
+
+                        sdkFeatureBandEntries.Add(new SdkFeatureBandEntry(
+                            sdkVersion,                  // version (latest SDK in band for this patch)
+                            featureBand,                 // band (e.g., "9.0.3xx")
+                            lifecycle?.GaDate,           // date
+                            $".NET SDK {featureBand}",   // label
+                            null,                        // support_phase omitted - implied by patch index
+                            HalHelpers.OrderLinks(bandLinks)));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Failed to extract SDK versions from {releaseJsonPath}: {ex.Message}");
+            }
+        }
+
+        // Load CVE disclosures from timeline directory based on release date
+        List<CveRecordSummary>? cveDisclosures = null;
+        string? timelineCveJsonPath = null;
+        string? timelineMonthIndexPath = null;
+        bool hasCveDisclosures = false;
+        string? cveYear = null;
+        string? cveMonth = null;
+
+        if (lifecycle?.GaDate != null)
+        {
+            var releaseDate = lifecycle.GaDate;
+            cveYear = releaseDate.Year.ToString("D4");
+            cveMonth = releaseDate.Month.ToString("D2");
+            var year = cveYear;
+            var month = cveMonth;
+            timelineCveJsonPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Cve}";
+            timelineMonthIndexPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Index}";
+
+            // Add link to release month (HAL+JSON - added before JSON links)
+            links[LinkRelations.Month] = new HalLink($"{Location.GitHubBaseUri}{timelineMonthIndexPath}")
+            {
+                Title = IndexTitles.TimelineMonthLink(year, month),
+            };
+
+            // Load CVE records from timeline directory
+            var cveRecords = await CveLoader.LoadForReleaseDateAsync(inputDir, releaseDate);
+
+            if (cveRecords != null)
+            {
+                // Filter by major version (e.g., "9.0")
+                var filteredCveRecords = CveTransformer.FilterByRelease(cveRecords, majorVersion);
+
+                if (filteredCveRecords?.Disclosures.Count > 0)
+                {
+                    hasCveDisclosures = true;
+
+                    // Sort disclosures by CVE ID for consistent ordering
+                    var sortedDisclosures = filteredCveRecords.Disclosures.OrderBy(d => d.Id).ToList();
+                    cveDisclosures = CveTransformer.ToSummaries(
+                        new Dotnet.Release.Cve.CveRecords(
+                            filteredCveRecords.LastUpdated,
+                            filteredCveRecords.Title,
+                            sortedDisclosures,
+                            filteredCveRecords.Products,
+                            filteredCveRecords.Packages,
+                            filteredCveRecords.Commits,
+                            filteredCveRecords.ProductName,
+                            filteredCveRecords.ProductCves,
+                            filteredCveRecords.PackageCves,
+                            filteredCveRecords.ReleaseCves,
+                            filteredCveRecords.SeverityCves,
+                            filteredCveRecords.CveReleases,
+                            filteredCveRecords.CveCommits
+                        )
+                    );
+                }
+            }
+        }
+
+        // Add CVE JSON link if there are disclosures
+        if (hasCveDisclosures && timelineCveJsonPath != null && cveYear != null && cveMonth != null)
+        {
+            var cveTitle = $"CVE records - {IndexTitles.FormatMonthYear(cveYear, cveMonth)}";
+            links[LinkRelations.CveJson] = new HalLink($"{Location.GitHubBaseUri}{timelineCveJsonPath}")
+            {
+                Title = cveTitle,
+                Type = MediaType.Json
+            };
+
+            // Add security-disclosures as semantic alias to month index
+            links[LinkRelations.SecurityDisclosures] = new HalLink($"{Location.GitHubBaseUri}{timelineMonthIndexPath}")
+            {
+                Title = $"Security disclosures - {IndexTitles.FormatMonthYear(cveYear, cveMonth)}",
+            };
+        }
+
+        // Build embedded content
+        // Extract sorted CVE IDs from disclosures (source of truth from cve.json)
+        IReadOnlyList<string>? sortedCveIds = null;
+        if (cveDisclosures != null && cveDisclosures.Count > 0)
+        {
+            sortedCveIds = cveDisclosures.Select(d => d.Id).ToList();
+        }
+
+        // Note: CVE disclosures are intentionally omitted from patch detail embedded content.
+        // CVEs are a timeline concept - use month or cve-json link for details.
+        PatchDetailIndexEmbedded? embedded = null;
+        if (runtimeEntry != null || sdkFeatureBandEntries != null || documentation != null)
+        {
+            embedded = new PatchDetailIndexEmbedded
+            {
+                Runtime = runtimeEntry,
+                Sdk = sdkFeatureBandEntries?.FirstOrDefault(),  // highest SDK (list is sorted descending)
+                SdkFeatureBands = sdkFeatureBandEntries,
+                Documentation = documentation
+            };
+        }
+
+        var patchDetailIndex = new PatchDetailIndex(
+            ReleaseKind.Patch,
+            $".NET Patch Release Index - {patchVersion}",
+            patchVersion,
+            lifecycle?.GaDate,
+            lifecycle?.Phase,
+            cveIds?.Count > 0,
+            sortedCveIds)
+        {
+            PrevPatchDate = prevPatchDate,
+            PrevSecurityPatchDate = prevSecurityPatchDate,
+            SdkVersion = highestSdkVersion,
+            SdkFeatureBands = sdkVersionsList,
+            Links = HalHelpers.OrderLinks(links),
+            Embedded = embedded
+        };
+
+        // Serialize
+        var patchDetailJson = JsonSerializer.Serialize(
+            patchDetailIndex,
+            ReleaseVersionIndexSerializerContext.Default.PatchDetailIndex);
+
+        // Add schema reference
+        var schemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.PatchDetailIndex}";
+        var updatedJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(patchDetailJson, schemaUri);
+
+        // Write to file - use patchDirPath for correct output location (handles preview/rc paths)
+        var outputPatchDir = Path.Combine(outputDir, patchDirPath);
+        if (!Directory.Exists(outputPatchDir))
+        {
+            Directory.CreateDirectory(outputPatchDir);
+        }
+
+        var indexPath = Path.Combine(outputPatchDir, FileNames.Index);
+        var finalJson = (updatedJson ?? patchDetailJson) + '\n';
+        await File.WriteAllTextAsync(indexPath, finalJson);
+    }
+
+    /// <summary>
+    /// Checks if a string looks like a version number (e.g., "9.0.111", "10.0.0-preview.1").
+    /// </summary>
+    private static bool IsVersionString(string name)
+    {
+        // Version strings start with a digit and contain at least one dot
+        return !string.IsNullOrEmpty(name)
+            && char.IsDigit(name[0])
+            && name.Contains('.');
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/ShipIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ShipIndexFiles.cs
@@ -1,0 +1,695 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Cve;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Summary;
+using System.Linq;
+using System.Globalization;
+using Dotnet.Release.CveHandler;
+
+namespace Dotnet.Release.IndexGenerator;
+
+// Helper record to track patch release information
+internal record PatchReleaseInfo(string PatchVersion, HashSet<string> SdkVersions);
+
+public class ShipIndexFiles
+{
+    // Links for timeline root index (timeline/index.json)
+    public static readonly OrderedDictionary<string, FileLink> TimelineRootFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.HistoryIndex, LinkStyle.Prod) },
+    };
+
+    // Links for timeline year index (timeline/YYYY/index.json)
+    public static readonly OrderedDictionary<string, FileLink> TimelineYearFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.HistoryIndex, LinkStyle.Prod) },
+    };
+
+    // Links for timeline month index (timeline/YYYY/MM/index.json) - JSON only, no markdown
+    public static readonly OrderedDictionary<string, FileLink> HistoryFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.HistoryIndex, LinkStyle.Prod) },
+        {FileNames.Cve, new FileLink(FileNames.Cve, LinkTitles.CveRecordsJson, LinkStyle.Prod) },
+    };
+
+    public static readonly OrderedDictionary<string, FileLink> ReleaseFileMappings = new()
+    {
+        {FileNames.Index, new FileLink(FileNames.Index, LinkTitles.DotNetReleaseIndex, LinkStyle.Prod) },
+        {"README.md", new FileLink("README.md", LinkTitles.DotNetReleaseNotes, LinkStyle.GitHub) },
+    };
+
+    public static async Task GenerateAsync(string inputPath, string outputPath, ReleaseHistory releaseHistory, List<MajorReleaseSummary> summaries)
+    {
+        var historyPath = Path.Combine(outputPath, FileNames.Directories.Timeline);
+
+        if (!Directory.Exists(historyPath))
+        {
+            Directory.CreateDirectory(historyPath);
+        }
+
+        var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+
+        var urlGenerator = (string relativePath, LinkStyle style) => style == LinkStyle.Prod
+    ? $"{Location.GitHubBaseUri}{relativePath}"
+    : $"https://github.com/dotnet/core/blob/main/release-notes/{relativePath}";
+
+
+        var halLinkGenerator = new TimelineHalLinkGenerator(inputPath, urlGenerator);
+
+        List<HistoryYearEntry> yearEntries = [];
+
+        HashSet<string> allReleases = [];
+
+        // Track the latest security month across all years (format: "YYYY-MM")
+        string? globalLatestSecurityMonth = null;
+
+        // Track previous security month for prev-security links (year, month)
+        // This is updated as we process months chronologically
+        (string Year, string Month)? previousSecurityMonth = null;
+        DateTimeOffset? previousSecurityMonthDate = null;
+
+        // Track previous month date for prev-month-date property
+        DateTimeOffset? previousMonthDate = null;
+
+        // Get sorted list of years for next/prev links
+        var sortedYears = releaseHistory.Years.Keys.OrderBy(y => y, numericStringComparer).ToList();
+
+        // Iterate years in chronological order for proper prev-security tracking
+        foreach (var yearKey in sortedYears)
+        {
+            var year = releaseHistory.Years[yearKey];
+            Console.WriteLine($"Processing year: {year.Year}");
+            var yearPath = Path.Combine(historyPath, year.Year);
+            if (!Directory.Exists(yearPath))
+            {
+                Directory.CreateDirectory(yearPath);
+            }
+
+            List<HistoryMonthSummary> monthSummaries = [];
+
+            HashSet<string> releasesForYear = [];
+
+            // Get sorted list of months for next/prev links
+            var sortedMonths = year.Months.Keys.OrderBy(m => m, numericStringComparer).ToList();
+
+            // Calculate year index once for cross-year month navigation
+            var currentYearIndex = sortedYears.IndexOf(year.Year);
+
+            // Iterate months in chronological order for proper prev-security tracking
+            foreach (var monthKey in sortedMonths)
+            {
+                var month = year.Months[monthKey];
+                Console.WriteLine($"Processing month: {month.Month} in year: {year.Year}");
+                var monthPath = Path.Combine(yearPath, month.Month);
+
+                if (!Directory.Exists(monthPath))
+                {
+                    Directory.CreateDirectory(monthPath);
+                }
+
+                var monthHistoryLinks = halLinkGenerator.Generate(
+                    monthPath,
+                    HistoryFileMappings.Values,
+                    (fileLink, key) => key switch
+                    {
+                        HalTerms.Self => IndexTitles.TimelineMonthLink(year.Year, month.Month),
+                        LinkRelations.CveJson => $"CVE records - {IndexTitles.FormatMonthYear(year.Year, month.Month)}",
+                        _ => fileLink.Title
+                    });
+
+                HashSet<string> monthReleases = [];
+                Dictionary<string, Dictionary<string, PatchReleaseInfo>> releasesByMajor = new();
+                DateTimeOffset? monthReleaseDate = null;
+
+                // Process each day in the month
+                foreach (var days in month.Days.Values)
+                {
+                    foreach (var day in days.Releases)
+                    {
+                        monthReleases.Add(day.MajorVersion);
+                        releasesForYear.Add(day.MajorVersion);
+                        allReleases.Add(day.MajorVersion);
+
+                        // Group patches by major version, keyed by runtime version
+                        if (!releasesByMajor.TryGetValue(day.MajorVersion, out var patches))
+                        {
+                            patches = new Dictionary<string, PatchReleaseInfo>();
+                            releasesByMajor[day.MajorVersion] = patches;
+                        }
+
+                        // Get runtime version for this release
+                        var runtimeVersion = day.Components.FirstOrDefault(c => c.Name == "Runtime")?.Version ?? day.PatchVersion;
+                        
+                        if (!patches.ContainsKey(runtimeVersion))
+                        {
+                            patches[runtimeVersion] = new PatchReleaseInfo(
+                                day.PatchVersion,
+                                new HashSet<string>()
+                            );
+                        }
+
+                        // Collect SDK versions for this runtime release
+                        foreach (var component in day.Components)
+                        {
+                            if (component.Name == "SDK")
+                            {
+                                patches[runtimeVersion].SdkVersions.Add(component.Version);
+                            }
+                        }
+
+                        // Track release date for the month (use the latest date from any patch)
+                        var patchSummaryForDate = summaries
+                            .FirstOrDefault(s => s.MajorVersion == day.MajorVersion)
+                            ?.PatchReleases.FirstOrDefault(p => p.PatchVersion == day.PatchVersion);
+                        if (patchSummaryForDate != null)
+                        {
+                            var patchDate = new DateTimeOffset(patchSummaryForDate.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero);
+                            if (monthReleaseDate == null || patchDate > monthReleaseDate)
+                            {
+                                monthReleaseDate = patchDate;
+                            }
+                        }
+                    }
+                }
+
+                // Load CVE information for the month
+                var inputMonthPath = Path.Combine(inputPath, "timeline", year.Year, month.Month);
+                var cveRecords = await CveLoader.LoadFromDirectoryAsync(inputMonthPath);
+                
+                // Generate CVE summaries once for the month
+                var cveSummariesForMonth = cveRecords != null ? CveTransformer.ToSummaries(cveRecords) : null;
+
+                // Prepare month index path for links
+                var monthIndexPath = Path.Combine(monthPath, FileNames.Index);
+                var monthIndexRelativePath = Path.GetRelativePath(inputPath, monthIndexPath);
+                var monthIndexPathValue = "/" + monthIndexRelativePath.Replace("\\", "/");
+
+                // Create simplified month summary for year index with proper self link (href only) and CVE links
+                var monthSummaryLinks = new Dictionary<string, HalLink>
+                {
+                    [HalTerms.Self] = new HalLink(urlGenerator(monthIndexRelativePath, LinkStyle.Prod))
+                };
+
+                // Add CVE JSON link if CVE records exist
+                if (cveRecords?.Disclosures.Count > 0)
+                {
+                    var cveJsonRelativePath = Path.GetRelativePath(inputPath, Path.Combine(monthPath, FileNames.Cve));
+                    var cveJsonPathValue = "/" + cveJsonRelativePath.Replace("\\", "/");
+
+                    monthSummaryLinks[LinkRelations.CveJson] = new HalLink(urlGenerator(cveJsonRelativePath, LinkStyle.Prod))
+                    {
+                        Type = MediaType.Json
+                    };
+                }
+
+                var monthSummary = new HistoryMonthSummary(
+                    month.Month,
+                    cveSummariesForMonth?.Count > 0,
+                    monthSummaryLinks
+                );
+                monthSummaries.Add(monthSummary);
+
+                // Create detailed month index with proper self link - href only
+                var monthIndexLinks = new Dictionary<string, HalLink>(monthHistoryLinks)
+                {
+                    [HalTerms.Self] = new HalLink(urlGenerator(monthIndexRelativePath, LinkStyle.Prod))
+                };
+
+                // Add next/prev links for month navigation (including cross-year boundaries)
+                var currentMonthIndex = sortedMonths.IndexOf(month.Month);
+
+                // Previous month link
+                if (currentMonthIndex > 0)
+                {
+                    // Previous month in same year
+                    var prevMonth = sortedMonths[currentMonthIndex - 1];
+                    var prevMonthIndexPath = Path.Combine(yearPath, prevMonth, FileNames.Index);
+                    var prevMonthIndexRelativePath = Path.GetRelativePath(inputPath, prevMonthIndexPath);
+                    var prevMonthPathValue = "/" + prevMonthIndexRelativePath.Replace("\\", "/");
+                    monthIndexLinks[LinkRelations.PrevMonth] = new HalLink(urlGenerator(prevMonthIndexRelativePath, LinkStyle.Prod))
+                    {
+                        Title = $"Previous month - {IndexTitles.FormatMonthYear(year.Year, prevMonth)}",
+                    };
+                }
+                else if (currentYearIndex > 0)
+                {
+                    // First month of year - link to last month of previous year
+                    var prevYear = sortedYears[currentYearIndex - 1];
+                    if (releaseHistory.Years.TryGetValue(prevYear, out var prevYearData))
+                    {
+                        var prevYearMonths = prevYearData.Months.Keys.OrderBy(m => m, numericStringComparer).ToList();
+                        if (prevYearMonths.Count > 0)
+                        {
+                            var lastMonthOfPrevYear = prevYearMonths.Last();
+                            var prevMonthIndexPath = Path.Combine(historyPath, prevYear, lastMonthOfPrevYear, FileNames.Index);
+                            var prevMonthIndexRelativePath = Path.GetRelativePath(inputPath, prevMonthIndexPath);
+                            var prevMonthPathValue = "/" + prevMonthIndexRelativePath.Replace("\\", "/");
+                            monthIndexLinks[LinkRelations.PrevMonth] = new HalLink(urlGenerator(prevMonthIndexRelativePath, LinkStyle.Prod))
+                            {
+                                Title = $"Previous month - {IndexTitles.FormatMonthYear(prevYear, lastMonthOfPrevYear)}",
+                            };
+                        }
+                    }
+                }
+
+                // NOTE: No "next" links - month indexes are immutable once created.
+                // Navigation pattern: start from latest-month and walk backwards via "prev" links.
+
+                // Add prev-security link for security month navigation
+                // This links to the previous month that had security releases (CVEs)
+                if (previousSecurityMonth != null)
+                {
+                    var prevSecurityMonthIndexPath = Path.Combine(historyPath, previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month, FileNames.Index);
+                    var prevSecurityMonthIndexRelativePath = Path.GetRelativePath(inputPath, prevSecurityMonthIndexPath);
+                    monthIndexLinks[LinkRelations.PrevSecurityMonth] = new HalLink(urlGenerator(prevSecurityMonthIndexRelativePath, LinkStyle.Prod))
+                    {
+                        Title = $"Previous security month - {IndexTitles.FormatMonthYear(previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month)}",
+                    };
+                }
+
+                // Add timeline-index link (grandparent)
+                monthIndexLinks[LinkRelations.Timeline] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{FileNames.Index}")
+                {
+                    Title = IndexTitles.TimelineIndexLink,
+                };
+
+                // Add year-index link (parent)
+                monthIndexLinks[LinkRelations.Year] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{year.Year}/{FileNames.Index}")
+                {
+                    Title = IndexTitles.TimelineYearLink(year.Year),
+                };
+
+                // Get the latest major version for the month
+                var monthLatestVersion = monthReleases.Max(numericStringComparer) ?? "unknown";
+
+                // Get sorted major releases for the month
+                var sortedMonthReleases = monthReleases
+                    .OrderByDescending(v => v, numericStringComparer)
+                    .ToList();
+
+                // Create embedded releases dictionary keyed by major version
+                // For each major version, take the latest patch (by version)
+                // Note: Timeline represents historical releases, so we include ALL patches (including previews)
+                // even if the major version has since reached GA. This preserves release history.
+                var embeddedReleases = new Dictionary<string, PatchReleaseVersionIndexEntry>();
+                foreach (var majorVersion in sortedMonthReleases)
+                {
+                    if (!releasesByMajor.TryGetValue(majorVersion, out var patches))
+                        continue;
+
+                    var summary = summaries.FirstOrDefault(s => s.MajorVersion == majorVersion);
+
+                    // Get the latest patch for this major version (by version string)
+                    var latestPatchVersion = patches.Keys
+                        .OrderByDescending(v => v, numericStringComparer)
+                        .First();
+                    var patchInfo = patches[latestPatchVersion];
+                    var phase = ReleaseStability.DeterminePhaseFromVersion(latestPatchVersion);
+
+                    // Filter CVE IDs for this major version
+                    IReadOnlyList<string>? patchCveIds = null;
+                    if (cveSummariesForMonth != null)
+                    {
+                        var filteredCves = cveSummariesForMonth
+                            .Where(cve => cve.AffectedReleases?.Contains(majorVersion) == true)
+                            .Select(cve => cve.Id)
+                            .ToList();
+                        patchCveIds = filteredCves.Count > 0 ? filteredCves : null;
+                    }
+
+                    // Get SDK versions for this specific patch
+                    var sdkVersions = patchInfo.SdkVersions.Count > 0
+                        ? patchInfo.SdkVersions.OrderByDescending(v => v, numericStringComparer).ToList()
+                        : null;
+
+                    // Find the patch summary to get PatchDirPath for the self link
+                    var patchSummaryForLinks = summary?.PatchReleases.FirstOrDefault(p => p.PatchVersion == latestPatchVersion);
+
+                    // Build links - self points to patch detail index
+                    // Use PatchDirPath if available (handles preview/rc paths correctly)
+                    var patchIndexPath2 = patchSummaryForLinks?.PatchDirPath != null
+                        ? $"{patchSummaryForLinks.PatchDirPath}/{FileNames.Index}"
+                        : $"{majorVersion}/{latestPatchVersion}/{FileNames.Index}";
+
+                    var patchLinks = new Dictionary<string, HalLink>
+                    {
+                        [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{patchIndexPath2}")
+                    };
+
+                    // Get release date from the summary's patch releases if available
+                    // Fall back to month release date if specific patch date not found
+                    var patchSummary = summary?.PatchReleases.FirstOrDefault(p => p.PatchVersion == latestPatchVersion);
+                    var releaseDate = patchSummary != null
+                        ? new DateTimeOffset(patchSummary.ReleaseDate, TimeOnly.MinValue, TimeSpan.Zero)
+                        : monthReleaseDate ?? new DateTimeOffset(int.Parse(year.Year), int.Parse(month.Month), 1, 0, 0, 0, TimeSpan.Zero);
+
+                    // Note: CVE IDs (cve_records) are intentionally omitted from patch entries.
+                    // CVEs are a timeline concept - use disclosures[] at month level or cve-json link.
+                    embeddedReleases[majorVersion] = new PatchReleaseVersionIndexEntry(
+                        latestPatchVersion,
+                        releaseDate,
+                        year.Year,
+                        month.Month,
+                        patchCveIds?.Count > 0,
+                        phase)
+                    {
+                        SdkVersion = sdkVersions?.FirstOrDefault(),
+                        Links = HalHelpers.OrderLinks(patchLinks)
+                    };
+                }
+
+                // Extract CVE IDs from disclosures for root-level quick enumeration
+                var monthCveIds = cveSummariesForMonth?.Select(d => d.Id).ToList();
+
+                var monthIndex = new HistoryMonthIndex(
+                    HistoryKind.Month,
+                    IndexTitles.TimelineMonthTitle(year.Year, month.Month),
+                    year.Year,
+                    month.Month,
+                    monthReleaseDate,
+                    cveSummariesForMonth?.Count > 0)
+                {
+                    PrevMonthDate = previousMonthDate,
+                    PrevSecurityMonthDate = previousSecurityMonthDate,
+                    CveRecords = monthCveIds?.Count > 0 ? monthCveIds : null,
+                    Links = HalHelpers.OrderLinks(monthIndexLinks),
+                    Embedded = new HistoryMonthIndexEmbedded
+                    {
+                        Patches = embeddedReleases.Count > 0 ? embeddedReleases : null,
+                        Disclosures = cveSummariesForMonth
+                    }
+                };
+
+                // Serialize to string first to add schema reference
+                var monthIndexJson = JsonSerializer.Serialize(
+                    monthIndex,
+                    HistoryYearIndexSerializerContext.Default.HistoryMonthIndex);
+
+                // Add schema reference
+                var monthSchemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.TimelineIndex}";
+                var updatedMonthIndexJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(monthIndexJson, monthSchemaUri);
+
+                // Write monthly index file
+                var currentMonthIndexPath = Path.Combine(monthPath, FileNames.Index);
+                var finalMonthIndexJson = (updatedMonthIndexJson ?? monthIndexJson) + '\n';
+                await File.WriteAllTextAsync(currentMonthIndexPath, finalMonthIndexJson);
+
+                // Update previousSecurityMonth tracker if this month had security releases
+                // This is used for prev-security links in subsequent months
+                if (cveSummariesForMonth?.Count > 0)
+                {
+                    previousSecurityMonth = (year.Year, month.Month);
+                    previousSecurityMonthDate = monthReleaseDate;
+                }
+
+                // Update previousMonthDate tracker for next month's prev-month-date
+                previousMonthDate = monthReleaseDate;
+            }
+
+            // Generate the root links for the year index
+            var yearHalLinks = halLinkGenerator.Generate(
+                yearPath,
+                TimelineYearFileMappings.Values,
+                (fileLink, key) => key == HalTerms.Self ? IndexTitles.TimelineYearLink(year.Year) : fileLink.Title);
+
+            // Add self link for year index (generated file may not exist yet) - href only
+            var yearIndexRelativePath = Path.GetRelativePath(inputPath, Path.Combine(yearPath, FileNames.Index));
+            yearHalLinks[HalTerms.Self] = new HalLink(urlGenerator(yearIndexRelativePath, LinkStyle.Prod));
+
+            // Add next/prev links for year navigation (currentYearIndex already calculated above)
+            if (currentYearIndex > 0)
+            {
+                var prevYear = sortedYears[currentYearIndex - 1];
+                var prevYearPath = Path.Combine(historyPath, prevYear);
+                var prevYearIndexPath = Path.Combine(prevYearPath, FileNames.Index);
+                var prevYearIndexRelativePath = Path.GetRelativePath(inputPath, prevYearIndexPath);
+                var prevYearPathValue = "/" + prevYearIndexRelativePath.Replace("\\", "/");
+                yearHalLinks[LinkRelations.PrevYear] = new HalLink(urlGenerator(prevYearIndexRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Previous year - {prevYear}",
+                };
+            }
+            // NOTE: No "next" links - year indexes are immutable after their last natural update.
+            // Navigation pattern: start from latest-year and walk backwards via "prev" links.
+
+            // Add timeline-index link (parent)
+            yearHalLinks[LinkRelations.Timeline] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{FileNames.Index}")
+            {
+                Title = IndexTitles.TimelineIndexLink,
+            };
+
+            // Get the latest major version for the year
+            var yearLatestVersion = releasesForYear.Max(numericStringComparer) ?? "unknown";
+
+            // Calculate latest month for this year (months are ordered chronologically, so last is latest)
+            var latestMonth = monthSummaries.LastOrDefault()?.Month;
+
+            // Add latest-month link if available
+            if (latestMonth != null)
+            {
+                var latestMonthPath = Path.Combine(yearPath, latestMonth, FileNames.Index);
+                var latestMonthRelativePath = Path.GetRelativePath(inputPath, latestMonthPath);
+                var latestMonthPathValue = "/" + latestMonthRelativePath.Replace("\\", "/");
+                yearHalLinks[LinkRelations.LatestMonth] = new HalLink(urlGenerator(latestMonthRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Latest month - {IndexTitles.FormatMonthYear(year.Year, latestMonth)}",
+                };
+            }
+
+            // Calculate latest security month for this year (months are ordered chronologically, so search from end)
+            var latestSecurityMonthThisYear = monthSummaries.LastOrDefault(m => m.Security)?.Month;
+
+            // Update global latest security month tracker (comparing YYYY-MM strings)
+            if (latestSecurityMonthThisYear != null)
+            {
+                var yearMonthString = $"{year.Year}-{latestSecurityMonthThisYear}";
+                if (globalLatestSecurityMonth == null ||
+                    string.Compare(yearMonthString, globalLatestSecurityMonth, StringComparison.Ordinal) > 0)
+                {
+                    globalLatestSecurityMonth = yearMonthString;
+                }
+            }
+
+            // Add latest-security-month link - use this year's latest, or fall back to previous year's
+            // previousSecurityMonth holds the most recent security month processed so far (across all years)
+            if (latestSecurityMonthThisYear != null)
+            {
+                var latestSecurityMonthPath = Path.Combine(yearPath, latestSecurityMonthThisYear, FileNames.Index);
+                var latestSecurityMonthRelativePath = Path.GetRelativePath(inputPath, latestSecurityMonthPath);
+                yearHalLinks[LinkRelations.LatestSecurityMonth] = new HalLink(urlGenerator(latestSecurityMonthRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Latest security month - {IndexTitles.FormatMonthYear(year.Year, latestSecurityMonthThisYear)}",
+                };
+
+                // Add latest-security-disclosures as semantic alias
+                yearHalLinks[LinkRelations.LatestSecurityDisclosures] = new HalLink(urlGenerator(latestSecurityMonthRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Latest security disclosures - {IndexTitles.FormatMonthYear(year.Year, latestSecurityMonthThisYear)}",
+                };
+
+                // Add latest-cve-json link for direct access to CVE data (only if cve.json exists)
+                var cveJsonPath = Path.Combine(inputPath, FileNames.Directories.Timeline, year.Year, latestSecurityMonthThisYear, FileNames.Cve);
+                if (File.Exists(cveJsonPath))
+                {
+                    yearHalLinks[LinkRelations.LatestCveJson] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{year.Year}/{latestSecurityMonthThisYear}/{FileNames.Cve}")
+                    {
+                        Title = $"Latest CVE records - {IndexTitles.FormatMonthYear(year.Year, latestSecurityMonthThisYear)}",
+                        Type = MediaType.Json
+                    };
+                }
+            }
+            else if (previousSecurityMonth != null)
+            {
+                // No security releases this year yet, fall back to previous year's latest security month
+                var latestSecurityMonthPath = Path.Combine(historyPath, previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month, FileNames.Index);
+                var latestSecurityMonthRelativePath = Path.GetRelativePath(inputPath, latestSecurityMonthPath);
+                yearHalLinks[LinkRelations.LatestSecurityMonth] = new HalLink(urlGenerator(latestSecurityMonthRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Latest security month - {IndexTitles.FormatMonthYear(previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month)}",
+                };
+
+                // Add latest-security-disclosures as semantic alias
+                yearHalLinks[LinkRelations.LatestSecurityDisclosures] = new HalLink(urlGenerator(latestSecurityMonthRelativePath, LinkStyle.Prod))
+                {
+                    Title = $"Latest security disclosures - {IndexTitles.FormatMonthYear(previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month)}",
+                };
+
+                // Add latest-cve-json link for direct access to CVE data (from previous year, only if cve.json exists)
+                var prevCveJsonPath = Path.Combine(inputPath, FileNames.Directories.Timeline, previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month, FileNames.Cve);
+                if (File.Exists(prevCveJsonPath))
+                {
+                    yearHalLinks[LinkRelations.LatestCveJson] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{previousSecurityMonth.Value.Year}/{previousSecurityMonth.Value.Month}/{FileNames.Cve}")
+                    {
+                        Title = $"Latest CVE records - {IndexTitles.FormatMonthYear(previousSecurityMonth.Value.Year, previousSecurityMonth.Value.Month)}",
+                        Type = MediaType.Json
+                    };
+                }
+            }
+
+            // Calculate latest release and sorted releases for the year
+            var sortedReleasesForYear = releasesForYear
+                .OrderByDescending(v => v, numericStringComparer)
+                .ToList();
+            // Latest release is the highest major version (two-part, e.g., "10.0")
+            var latestReleaseForYear = sortedReleasesForYear.FirstOrDefault();
+
+            // Add latest-major link if available
+            if (latestReleaseForYear != null)
+            {
+                var latestReleaseIndexPath = $"{latestReleaseForYear}/{FileNames.Index}";
+                yearHalLinks[LinkRelations.LatestMajor] = new HalLink($"{Location.GitHubBaseUri}{latestReleaseIndexPath}")
+                {
+                    Title = $"Latest major - .NET {latestReleaseForYear}",
+                };
+            }
+
+            // Determine the effective latest security month (this year or fallback to previous)
+            var effectiveLatestSecurityMonth = latestSecurityMonthThisYear ?? previousSecurityMonth?.Month;
+
+            // Create the year index (e.g., release-notes/2025/index.json)
+            var yearHistory = new HistoryYearIndex(
+                HistoryKind.Year,
+                IndexTitles.TimelineYearTitle(year.Year),
+                year.Year)
+            {
+                LatestMonth = latestMonth,
+                LatestSecurityMonth = effectiveLatestSecurityMonth,
+                LatestMajor = latestReleaseForYear,
+                MajorReleases = sortedReleasesForYear.Count > 0 ? sortedReleasesForYear : null,
+                Links = HalHelpers.OrderLinks(yearHalLinks)
+            };
+
+            yearHistory.Embedded = new HistoryYearIndexEmbedded
+            {
+                Months = monthSummaries.AsEnumerable().Reverse().ToList()
+            };
+
+            // Serialize to string first to add schema reference
+            var yearIndexJson = JsonSerializer.Serialize(
+                yearHistory,
+                HistoryYearIndexSerializerContext.Default.HistoryYearIndex);
+
+            // Add schema reference
+            var yearSchemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.TimelineIndex}";
+            var updatedYearIndexJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(yearIndexJson, yearSchemaUri);
+
+            var yearIndexPath = Path.Combine(yearPath, FileNames.Index);
+            var finalYearIndexJson = (updatedYearIndexJson ?? yearIndexJson) + '\n';
+            await File.WriteAllTextAsync(yearIndexPath, finalYearIndexJson);
+
+            // for the overall index
+
+            var overallYearHalLinks = halLinkGenerator.Generate(
+                yearPath,
+                HistoryFileMappings.Values,
+                (fileLink, key) => key == HalTerms.Self ? IndexTitles.TimelineYearLink(year.Year) : fileLink.Title);
+
+            // NOTE: Do NOT add latest-month link here - it changes monthly
+            // and would cause the root timeline/index.json to change frequently.
+            // The latest-month link belongs in the year-level indexes (e.g., timeline/2025/index.json).
+
+            // Strip titles from all links for embedded year entries - context established by parent
+            var minimalYearLinks = overallYearHalLinks.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new HalLink(kvp.Value.Href) { Type = kvp.Value.Type });
+
+            yearEntries.Add(new HistoryYearEntry(year.Year)
+            {
+                MajorReleases = [.. sortedReleasesForYear],
+                Links = HalHelpers.OrderLinks(minimalYearLinks)
+            });
+        }
+
+        var fullIndexLinks = halLinkGenerator.Generate(
+            historyPath,
+            TimelineRootFileMappings.Values,
+            (fileLink, key) => key == HalTerms.Self ? IndexTitles.TimelineIndexLink : fileLink.Title);
+
+        // Strip title from self link (href is sufficient)
+        if (fullIndexLinks.TryGetValue(HalTerms.Self, out var selfLink))
+        {
+            fullIndexLinks[HalTerms.Self] = new HalLink(selfLink.Href);
+        }
+
+        // Calculate latest year
+        var latestYear = sortedYears.LastOrDefault();
+
+        // Find latest stable release and latest LTS release for cross-references
+        // Uses shared ReleaseStability methods to ensure consistent logic across tools
+        var releaseData = summaries.Select(s => (s.MajorVersion, (Lifecycle?)s.Lifecycle));
+        var latestVersion = ReleaseStability.FindLatestVersion(releaseData, numericStringComparer);
+        var latestLtsVersion = ReleaseStability.FindLatestLtsVersion(releaseData, numericStringComparer);
+        var latestRelease = latestVersion != null ? summaries.First(s => s.MajorVersion == latestVersion) : null;
+        var latestLtsRelease = latestLtsVersion != null ? summaries.First(s => s.MajorVersion == latestLtsVersion) : null;
+
+        // Add releases-index link pointing back to root index.json
+        fullIndexLinks[LinkRelations.Root] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Index}")
+        {
+            Title = IndexTitles.VersionIndexTitle,
+        };
+
+        // Add cross-reference links to latest versions (from releases-index)
+        if (latestRelease != null)
+        {
+            fullIndexLinks[LinkRelations.LatestMajor] = new HalLink($"{Location.GitHubBaseUri}{latestRelease.MajorVersion}/{FileNames.Index}")
+            {
+                Title = $"Latest major release - .NET {latestRelease.MajorVersion}",
+            };
+        }
+
+        if (latestLtsRelease != null)
+        {
+            fullIndexLinks[LinkRelations.LatestLtsMajor] = new HalLink($"{Location.GitHubBaseUri}{latestLtsRelease.MajorVersion}/{FileNames.Index}")
+            {
+                Title = $"Latest LTS major release - .NET {latestLtsRelease.MajorVersion}",
+            };
+        }
+
+        // Add latest-year link
+        if (latestYear != null)
+        {
+            fullIndexLinks[LinkRelations.LatestYear] = new HalLink($"{Location.GitHubBaseUri}{FileNames.Directories.Timeline}/{latestYear}/{FileNames.Index}")
+            {
+                Title = $"Latest year - {latestYear}",
+            };
+        }
+
+        // NOTE: Do NOT add latest-security-month link here - it changes frequently
+        // and would cause the root timeline/index.json to change with every security release.
+        // Users can find security releases by navigating through year -> month indexes.
+
+        // Get the latest major version for the root history index
+        var rootLatestVersion = allReleases.Max(numericStringComparer) ?? "unknown";
+
+        // Create the history index
+        var historyIndex = new ReleaseHistoryIndex(
+            HistoryKind.Timeline,
+            IndexTitles.TimelineIndexTitle)
+        {
+            LatestYear = latestYear,
+            LatestMajor = latestRelease?.MajorVersion,
+            LatestLtsMajor = latestLtsRelease?.MajorVersion,
+            Links = HalHelpers.OrderLinks(fullIndexLinks),
+            Embedded = new ReleaseHistoryIndexEmbedded
+            {
+                Years = [.. yearEntries.OrderByDescending(e => e.Year, StringComparer.OrdinalIgnoreCase)]
+            }
+        };
+
+        // Serialize to string first to add schema reference
+        var historyIndexJson = JsonSerializer.Serialize(
+            historyIndex,
+            ReleaseHistoryIndexSerializerContext.Default.ReleaseHistoryIndex);
+
+        // Add schema reference
+        var historySchemaUri = $"{Location.GitHubBaseUri}{FileNames.Directories.Schemas}/{FileNames.Schemas.TimelineIndex}";
+        var updatedHistoryIndexJson = JsonSchemaInjector.JsonSchemaInjector.AddSchemaToContent(historyIndexJson, historySchemaUri);
+
+        var historyIndexPath = Path.Combine(historyPath, FileNames.Index);
+        var finalHistoryIndexJson = (updatedHistoryIndexJson ?? historyIndexJson) + '\n';
+        await File.WriteAllTextAsync(historyIndexPath, finalHistoryIndexJson);
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/TimelineHalLinkGenerator.cs
+++ b/src/Dotnet.Release.IndexGenerator/TimelineHalLinkGenerator.cs
@@ -1,0 +1,122 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class TimelineHalLinkGenerator(string rootPath, Func<string, LinkStyle, string> urlGenerator)
+{
+    private readonly string _rootPath = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
+    private readonly Func<string, LinkStyle, string> _urlGenerator = urlGenerator ?? throw new ArgumentNullException(nameof(urlGenerator));
+
+    public Dictionary<string, HalLink> Generate(string path, IEnumerable<FileLink> fileLinks, Func<FileLink, string, string> titleGenerator, bool includeSelf = true)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(fileLinks);
+        ArgumentNullException.ThrowIfNull(titleGenerator);
+
+        var result = new Dictionary<string, HalLink>();
+        bool isSelf = includeSelf;
+
+        foreach (var fileLink in fileLinks)
+        {
+            var filePath = Path.Combine(path, fileLink.File);
+
+            if (!File.Exists(filePath))
+            {
+                continue;
+            }
+
+            string filename = fileLink.File;
+            string relativePath = Path.GetRelativePath(_rootPath, filePath);
+            string pathValue = "/" + relativePath.Replace("\\", "/");
+            string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
+            string extension = Path.GetExtension(filename).ToLowerInvariant();
+            bool isMarkdown = ".md".Equals(extension, StringComparison.OrdinalIgnoreCase);
+            
+            // Map files to semantic HAL+JSON relations
+            if (filename == "timeline/index.json")
+            {
+                name = LinkRelations.Timeline;
+            }
+            else if (filename == "usage.md")
+            {
+                name = "help";
+            }
+            else if (filename == "glossary.md")
+            {
+                name = "glossary";
+            }
+            else if (filename == "support.md")
+            {
+                name = "about";
+            }
+            // Special case for manifest.json to use correct key name
+            else if (filename == "manifest.json")
+            {
+                name = LinkRelations.Manifest;
+            }
+            // Skip releases.json - too large for LLM consumption
+            else if (filename == "releases.json")
+            {
+                continue;
+            }
+            // Special case for release.json to match cve-json pattern
+            else if (filename == "release.json")
+            {
+                name = "release-json";
+            }
+            // Special case for cve.json to use consistent naming
+            else if (filename == "cve.json")
+            {
+                name = LinkRelations.CveJson;
+            }
+            // Special case for supported-os.json - non-HAL JSON needs -json suffix
+            else if (filename == "supported-os.json")
+            {
+                name = "supported-os-json";
+            }
+            // Special case for linux-packages.json - non-HAL JSON needs -json suffix
+            else if (filename == "linux-packages.json")
+            {
+                name = "linux-packages-json";
+            }
+            // Special case for README.md to use correct key name
+            else if (filename == "README.md")
+            {
+                name = "release-readme";
+            }
+            var fileType = MediaType.GetFileType(filename);
+
+            string? selfKey = null;
+            if (isSelf)
+            {
+                selfKey = HalTerms.Self;
+                isSelf = false; // Only the first link is self
+            }
+
+            var linkStyles = new[] { LinkStyle.Prod, LinkStyle.GitHub };
+            foreach (var style in linkStyles)
+            {
+                if (fileLink.Style.HasFlag(style))
+                {
+                    // Raw content (Prod) is markdown, GitHub blob renders as HTML
+                    var linkKey = selfKey ?? (isMarkdown ? $"{name}-{(style == LinkStyle.Prod ? "markdown" : "html")}" : name);
+                    var baseTitle = titleGenerator(fileLink, linkKey);
+                    // Don't append "(HTML)" if the title already contains it (custom title provided)
+                    var title = isMarkdown && style == LinkStyle.GitHub && !baseTitle.Contains("(HTML)")
+                        ? $"{baseTitle} (HTML)"
+                        : baseTitle;
+
+                    // GitHub blob view renders markdown as HTML
+                    var linkType = style == LinkStyle.GitHub && isMarkdown ? MediaType.Html : fileType;
+                    result[linkKey] = new HalLink(_urlGenerator(relativePath, style))
+                        {
+                            Title = linkKey == HalTerms.Self ? null : title,
+                            Type = linkType == MediaType.HalJson ? null : linkType
+                        };
+                }
+            }
+        }
+
+        return HalHelpers.OrderLinks(result);
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/TimelineIndexHelpers.cs
+++ b/src/Dotnet.Release.IndexGenerator/TimelineIndexHelpers.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class TimelineIndexHelpers
+{
+
+    private static readonly OrderedDictionary<string, ReleaseKindMapping> _halFileMappings = new()
+    {
+        { FileNames.Index, new ReleaseKindMapping("index", FileNames.Index, ReleaseKind.Root, MediaType.Json) },
+        { FileNames.Release, new ReleaseKindMapping("release", FileNames.Release, ReleaseKind.Patch, MediaType.Json) },
+        { FileNames.Manifest, new ReleaseKindMapping("manifest", FileNames.Manifest, ReleaseKind.Manifest, MediaType.Json) },
+        { "usage.md", new ReleaseKindMapping("usage", "usage.md", ReleaseKind.Content, MediaType.Markdown) },
+        { "terminology.md", new ReleaseKindMapping("terminology", "terminology.md", ReleaseKind.Content, MediaType.Markdown) },
+        { $"{FileNames.Directories.Timeline}/{FileNames.Index}", new ReleaseKindMapping("release-timeline", $"{FileNames.Directories.Timeline}/{FileNames.Index}", ReleaseKind.Root, MediaType.HalJson) }
+    };
+
+    public static readonly OrderedDictionary<string, FileLink> AuxFileMappings = new()
+    {
+        {FileNames.SupportedOs, new FileLink(FileNames.SupportedOs, "Supported OSes", LinkStyle.Prod) },
+        {"supported-os.md", new FileLink("supported-os.md", "Supported OSes", LinkStyle.Prod | LinkStyle.GitHub) },
+        {"linux-packages.json", new FileLink("linux-packages.json", "Linux Packages", LinkStyle.Prod) },
+        {"linux-packages.md", new FileLink("linux-packages.md", "Linux Packages", LinkStyle.Prod | LinkStyle.GitHub) },
+        {"README.md", new FileLink("README.md", "Release Notes", LinkStyle.GitHub) }
+    };
+
+    public static IEnumerable<HalTuple> GetHalLinksForPath(string targetPath, PathContext pathContext, string subtitle)
+    {
+        var dict = new Dictionary<string, HalLink>();
+        bool isSelf = true;
+
+        foreach (ReleaseKindMapping mapping in _halFileMappings.Values)
+        {
+            var file = Path.Combine(targetPath, mapping.Filename);
+            HalTuple? tuple = GetLinkForFile(pathContext, file, isSelf, true, subtitle);
+            if (tuple is null)
+            {
+                continue; // Skip if the file does not exist or is not valid
+            }
+
+            isSelf = false; // Only the first entry is self
+            yield return tuple;
+        }
+    }
+
+    public static IEnumerable<HalTuple> GetAuxHalLinksForPath(string targetPath, PathContext pathContext, IEnumerable<FileLink> files)
+    {
+        foreach (var mapping in files)
+        {
+            var file = Path.Combine(targetPath, mapping.File);
+
+            if (!File.Exists(file))
+            {
+                continue;
+            }
+
+            string relativePath = Path.GetRelativePath(pathContext.Basepath, file);
+            string urlRelativePath = Path.GetRelativePath(pathContext.UrlBasePath ?? pathContext.Basepath, file);
+            string pathValue = "/" + relativePath.Replace("\\", "/");
+            string filename = mapping.File;
+            string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
+            string extension = Path.GetExtension(filename).ToLowerInvariant();
+            bool isMarkdown = ".md".Equals(extension, StringComparison.OrdinalIgnoreCase);
+
+            if (mapping.Style.HasFlag(LinkStyle.Prod))
+            {
+                // Raw content is the default (no suffix for markdown)
+                var key = isMarkdown ? $"{name}-markdown" : name;
+                yield return new HalTuple(key, ReleaseKind.Content, new HalLink(GetProdPath(urlRelativePath))
+                {
+                    Title = mapping.Title,
+                    Type = extension switch
+                    {
+                        ".json" => MediaType.Json,
+                        ".md" => MediaType.Markdown,
+                        _ => MediaType.Text
+                    }
+                });
+            }
+
+            if (mapping.Style.HasFlag(LinkStyle.GitHub))
+            {
+                // GitHub blob view renders markdown as HTML
+                var key = isMarkdown ? $"{name}-html" : name;
+                yield return new HalTuple(key, ReleaseKind.Content, new HalLink(GetGitHubPath(urlRelativePath))
+                {
+                    Title = $"{mapping.Title} (HTML)",
+                    Type = MediaType.Html
+                });
+            }
+        }
+    }
+
+    public static HalTuple? GetLinkForFile(PathContext pathContext, string file, bool isSelf, bool mustExist, string subtitle)
+    {
+        if (mustExist && !File.Exists(file))
+        {
+            return null;
+        }
+
+        var filename = Path.GetFileNameWithoutExtension(file);
+        var relativePath = Path.GetRelativePath(pathContext.Basepath, file);
+        var urlRelativePath = Path.GetRelativePath(pathContext.UrlBasePath ?? pathContext.Basepath, file);
+        var pathValue = "/" + relativePath.Replace("\\", "/");
+        var kind = _halFileMappings.TryGetValue(relativePath, out var mapping) ? mapping.Kind : ReleaseKind.Unknown;
+        var type = _halFileMappings.TryGetValue(relativePath, out var fileType) ? fileType.FileType : MediaType.Text;
+        var prodPath = GetProdPath(urlRelativePath);
+
+        var link = new HalLink(prodPath)
+        {
+            Title = $"{subtitle} {kind}",
+            Type = type
+        };
+
+        string defaultKey = mapping?.Kind.ToString().ToLowerInvariant() ?? filename.ToLowerInvariant();
+
+        if (defaultKey == "content")
+        {
+            defaultKey = mapping?.Name.ToLowerInvariant() ?? filename.ToLowerInvariant();
+        }
+
+        var key = isSelf ? HalTerms.Self : defaultKey;
+
+        return new HalTuple(key, kind, link);
+    }
+
+    public static string GetProdPath(string relativePath) => GetRawGitHubBranchPath(relativePath);
+
+    public static string GetRawGitHubBranchPath(string relativePath) =>
+      $"{Location.GitHubBaseUri}{relativePath}";
+
+
+    public static string GetGitHubPath(string relativePath) =>
+    $"https://github.com/dotnet/core/blob/main/release-notes/{relativePath}";
+}

--- a/src/Dotnet.Release.IndexGenerator/VersionIndexHalLinkGenerator.cs
+++ b/src/Dotnet.Release.IndexGenerator/VersionIndexHalLinkGenerator.cs
@@ -1,0 +1,163 @@
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class VersionIndexHalLinkGenerator(string rootPath, Func<string, LinkStyle, string> urlGenerator)
+{
+    private readonly string _rootPath = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
+    private readonly Func<string, LinkStyle, string> _urlGenerator = urlGenerator ?? throw new ArgumentNullException(nameof(urlGenerator));
+
+    public Dictionary<string, HalLink> Generate(string path, IEnumerable<FileLink> fileLinks, Func<FileLink, string, string> titleGenerator, bool includeSelf = true)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(fileLinks);
+        ArgumentNullException.ThrowIfNull(titleGenerator);
+
+        var result = new Dictionary<string, HalLink>();
+        bool isSelf = includeSelf;
+
+        foreach (var fileLink in fileLinks)
+        {
+            var filePath = Path.Combine(path, fileLink.File);
+
+            if (!File.Exists(filePath))
+            {
+                continue;
+            }
+
+            string filename = fileLink.File;
+            
+            // Calculate path relative to release-notes root (starts with /)
+            // If path starts with ../, it's relative to parent of rootPath (repo root)
+            string pathValue;
+            if (filename.StartsWith("../"))
+            {
+                // File is outside release-notes (e.g., ../llms/usage.md)
+                // Remove the ../ prefix and add leading slash
+                pathValue = "/" + filename.Substring(3); // Remove "../" and add "/"
+            }
+            else
+            {
+                // File is within release-notes, calculate normally and add leading slash
+                string relativePath = Path.GetRelativePath(_rootPath, filePath);
+                pathValue = "/" + relativePath.Replace("\\", "/");
+            }
+            
+            string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
+            string extension = Path.GetExtension(filename).ToLowerInvariant();
+            bool isMarkdown = ".md".Equals(extension, StringComparison.OrdinalIgnoreCase);
+            
+            // Map files to semantic HAL+JSON relations
+            if (filename == "timeline/index.json")
+            {
+                name = LinkRelations.Timeline;
+            }
+            else if (filename == "release-history/index.json")
+            {
+                name = "release-history";
+            }
+            else if (filename == "README.md" || filename.EndsWith("/README.md"))
+            {
+                name = "usage";
+            }
+            else if (filename == "quick-ref.md" || filename.EndsWith("/quick-ref.md"))
+            {
+                name = "quick-reference";
+            }
+            else if (filename == "glossary.md" || filename.EndsWith("/glossary.md"))
+            {
+                name = "glossary";
+            }
+            else if (filename == "support.md")
+            {
+                name = "about";
+            }
+            // Special case for manifest.json to use correct key name
+            else if (filename == "manifest.json")
+            {
+                name = LinkRelations.Manifest;
+            }
+            // Skip releases.json - too large for LLM consumption
+            else if (filename == "releases.json")
+            {
+                continue;
+            }
+            // Special case for release.json to match cve-json pattern
+            else if (filename == "release.json")
+            {
+                name = "release-json";
+            }
+            // Special case for supported-os.json - non-HAL JSON needs -json suffix
+            else if (filename == "supported-os.json")
+            {
+                name = "supported-os-json";
+            }
+            // Special case for linux-packages.json - non-HAL JSON needs -json suffix
+            else if (filename == "linux-packages.json")
+            {
+                name = "linux-packages-json";
+            }
+            // Special case for os-packages.json - non-HAL JSON needs -json suffix
+            else if (filename == "os-packages.json")
+            {
+                name = "os-packages-json";
+            }
+            // Special case for README.md to use correct key name
+            else if (filename == "README.md")
+            {
+                name = "release-readme";
+            }
+            var fileType = MediaType.GetFileType(filename);
+
+            string? selfKey = null;
+            if (isSelf)
+            {
+                selfKey = HalTerms.Self;
+                isSelf = false; // Only the first link is self
+            }
+
+            var linkStyles = new[] { LinkStyle.Prod, LinkStyle.GitHub };
+            foreach (var style in linkStyles)
+            {
+                if (fileLink.Style.HasFlag(style))
+                {
+                    // Use pathValue without leading slash for URL generation
+                    string urlPath = pathValue.TrimStart('/');
+                    // Raw content (Prod) is markdown, GitHub blob renders as HTML
+                    var linkKey = selfKey ?? (isMarkdown ? $"{name}-{(style == LinkStyle.Prod ? "markdown" : "html")}" : name);
+                    var baseTitle = titleGenerator(fileLink, linkKey);
+                    var title = isMarkdown && style == LinkStyle.GitHub ? $"{baseTitle} (HTML)" : baseTitle;
+
+                    // GitHub blob view renders markdown as HTML
+                    var linkType = style == LinkStyle.GitHub && isMarkdown ? MediaType.Html : fileType;
+                    result[linkKey] = new HalLink(_urlGenerator(urlPath, style))
+                        {
+                            Title = linkKey == HalTerms.Self ? null : title,
+                            Type = linkType == MediaType.HalJson ? null : linkType
+                        };
+                }
+            }
+        }
+
+        return HalHelpers.OrderLinks(result);
+    }
+
+    /// <summary>
+    /// Expands a partial link (with relative path) to a full HalLink with absolute URL.
+    /// </summary>
+    public HalLink ExpandLink(HalLink partialLink, string title)
+    {
+        // If href is a relative path (starts with /), expand it to full URL
+        var href = partialLink.Href;
+        if (href.StartsWith("/"))
+        {
+            href = _urlGenerator(href.TrimStart('/'), LinkStyle.Prod);
+        }
+
+        return new HalLink(href)
+        {
+            Title = partialLink.Title ?? title,
+            Type = partialLink.Type ?? MediaType.HalJson
+        };
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/VersionIndexHelpers.cs
+++ b/src/Dotnet.Release.IndexGenerator/VersionIndexHelpers.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using Dotnet.Release;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+public class VersionIndexHelpers
+{
+
+    private static readonly OrderedDictionary<string, ReleaseKindMapping> _halFileMappings = new()
+    {
+        { FileNames.Index, new ReleaseKindMapping("index", FileNames.Index, ReleaseKind.Root, MediaType.Json) },
+        { FileNames.Release, new ReleaseKindMapping("release", FileNames.Release, ReleaseKind.Patch, MediaType.Json) },
+        { FileNames.Manifest, new ReleaseKindMapping("manifest", FileNames.Manifest, ReleaseKind.Manifest, MediaType.Json) },
+        { "usage.md", new ReleaseKindMapping("usage", "usage.md", ReleaseKind.Content, MediaType.Markdown) },
+        { "terminology.md", new ReleaseKindMapping("terminology", "terminology.md", ReleaseKind.Content, MediaType.Markdown) },
+        { $"release-history/{FileNames.Index}", new ReleaseKindMapping("release-history", $"release-history/{FileNames.Index}", ReleaseKind.Root, MediaType.HalJson) }
+    };
+
+    public static readonly OrderedDictionary<string, FileLink> AuxFileMappings = new()
+    {
+        {FileNames.SupportedOs, new FileLink(FileNames.SupportedOs, "Supported OSes", LinkStyle.Prod) },
+        {"supported-os.md", new FileLink("supported-os.md", "Supported OSes", LinkStyle.Prod | LinkStyle.GitHub) },
+        {"linux-packages.json", new FileLink("linux-packages.json", "Linux Packages", LinkStyle.Prod) },
+        {"linux-packages.md", new FileLink("linux-packages.md", "Linux Packages", LinkStyle.Prod | LinkStyle.GitHub) },
+        {"README.md", new FileLink("README.md", "Release Notes", LinkStyle.GitHub) }
+    };
+
+    public static IEnumerable<HalTuple> GetHalLinksForPath(string targetPath, PathContext pathContext, string subtitle)
+    {
+        var dict = new Dictionary<string, HalLink>();
+        bool isSelf = true;
+
+        foreach (ReleaseKindMapping mapping in _halFileMappings.Values)
+        {
+            var file = Path.Combine(targetPath, mapping.Filename);
+            HalTuple? tuple = GetLinkForFile(pathContext, file, isSelf, true, subtitle);
+            if (tuple is null)
+            {
+                continue; // Skip if the file does not exist or is not valid
+            }
+
+            isSelf = false; // Only the first entry is self
+            yield return tuple;
+        }
+    }
+
+    public static IEnumerable<HalTuple> GetAuxHalLinksForPath(string targetPath, PathContext pathContext, IEnumerable<FileLink> files)
+    {
+        foreach (var mapping in files)
+        {
+            var file = Path.Combine(targetPath, mapping.File);
+
+            if (!File.Exists(file))
+            {
+                continue;
+            }
+
+            string relativePath = Path.GetRelativePath(pathContext.Basepath, file);
+            string urlRelativePath = Path.GetRelativePath(pathContext.UrlBasePath ?? pathContext.Basepath, file);
+            string pathValue = "/" + relativePath.Replace("\\", "/");
+            string filename = mapping.File;
+            string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
+            string extension = Path.GetExtension(filename).ToLowerInvariant();
+            bool isMarkdown = ".md".Equals(extension, StringComparison.OrdinalIgnoreCase);
+
+            if (mapping.Style.HasFlag(LinkStyle.Prod))
+            {
+                // Raw content is the default (no suffix for markdown)
+                var key = isMarkdown ? $"{name}-markdown" : name;
+                yield return new HalTuple(key, ReleaseKind.Content, new HalLink(GetProdPath(urlRelativePath))
+                {
+                    Title = mapping.Title,
+                    Type = extension switch
+                    {
+                        ".json" => MediaType.Json,
+                        ".md" => MediaType.Markdown,
+                        _ => MediaType.Text
+                    }
+                });
+            }
+
+            if (mapping.Style.HasFlag(LinkStyle.GitHub))
+            {
+                // GitHub blob view renders markdown as HTML
+                var key = isMarkdown ? $"{name}-html" : name;
+                yield return new HalTuple(key, ReleaseKind.Content, new HalLink(GetGitHubPath(urlRelativePath))
+                {
+                    Title = $"{mapping.Title} (HTML)",
+                    Type = MediaType.Html
+                });
+            }
+        }
+    }
+
+    public static HalTuple? GetLinkForFile(PathContext pathContext, string file, bool isSelf, bool mustExist, string subtitle)
+    {
+        if (mustExist && !File.Exists(file))
+        {
+            return null;
+        }
+
+        var filename = Path.GetFileNameWithoutExtension(file);
+        var relativePath = Path.GetRelativePath(pathContext.Basepath, file);
+        var urlRelativePath = Path.GetRelativePath(pathContext.UrlBasePath ?? pathContext.Basepath, file);
+        var pathValue = "/" + relativePath.Replace("\\", "/");
+        var kind = _halFileMappings.TryGetValue(relativePath, out var mapping) ? mapping.Kind : ReleaseKind.Unknown;
+        var type = _halFileMappings.TryGetValue(relativePath, out var fileType) ? fileType.FileType : MediaType.Text;
+        var prodPath = GetProdPath(urlRelativePath);
+
+        var link = new HalLink(prodPath)
+        {
+            Title = $"{subtitle} {kind}",
+            Type = type
+        };
+
+        string defaultKey = mapping?.Kind.ToString().ToLowerInvariant() ?? filename.ToLowerInvariant();
+
+        if (defaultKey == "content")
+        {
+            defaultKey = mapping?.Name.ToLowerInvariant() ?? filename.ToLowerInvariant();
+        }
+
+        var key = isSelf ? HalTerms.Self : defaultKey;
+
+        return new HalTuple(key, kind, link);
+    }
+
+    public static string GetProdPath(string relativePath) => GetRawGitHubBranchPath(relativePath);
+
+    public static string GetRawGitHubBranchPath(string relativePath) =>
+      $"{Location.GitHubBaseUri}{relativePath}";
+
+
+    public static string GetGitHubPath(string relativePath) =>
+    $"https://github.com/dotnet/core/blob/main/release-notes/{relativePath}";
+}

--- a/src/Dotnet.Release.Releases/PatchReleaseOverview.cs
+++ b/src/Dotnet.Release.Releases/PatchReleaseOverview.cs
@@ -39,7 +39,11 @@ public record PatchRelease(
     SdkComponent Sdk,
 
     [property: Description("ASP.NET Core component information.")]
-    AspNetCoreComponent AspnetcoreRuntime)
+    AspNetCoreComponent AspnetcoreRuntime,
+
+    [property: Description("SDK components of the release (may include multiple feature bands)."),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    IList<SdkComponent>? Sdks = null)
 {
     [Description("Windows Desktop component information."),
      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Release.Graph\Dotnet.Release.Graph.csproj" />
+    <ProjectReference Include="..\Dotnet.Release.IndexGenerator\Dotnet.Release.IndexGenerator.csproj" />
     <ProjectReference Include="..\Dotnet.Release.Releases\Dotnet.Release.Releases.csproj" />
     <ProjectReference Include="..\Dotnet.Release.Support\Dotnet.Release.Support.csproj" />
     <ProjectReference Include="..\Dotnet.Release\Dotnet.Release.csproj" />

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -1,11 +1,14 @@
 using System.Text.Json;
 using Dotnet.Release;
+using Dotnet.Release.IndexGenerator;
 using Dotnet.Release.Releases;
+using Dotnet.Release.Summary;
 using Dotnet.Release.Support;
 using Dotnet.Release.Tools;
 
 // Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]
 //        dotnet-release generate <type> --export-template
+//        dotnet-release generate version-index|timeline-index|llms-index|indexes <input-dir> [output-dir] [--url-root <url>]
 //        dotnet-release verify <type> <version> [path-or-url]
 //        dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]
 // Types: supported-os, os-packages
@@ -65,10 +68,12 @@ if (args.Length > 2 && args[2] == "--export-template")
 }
 
 // Types that don't require a version number
-if (type is "releases-index" or "releases")
+if (type is "releases-index" or "releases" or "version-index" or "timeline-index" or "llms-index" or "indexes")
 {
     string genPath = ".";
+    string? genOutputPath = null;
     string? genTemplatePath = null;
+    string? genUrlRoot = null;
 
     for (int i = 2; i < args.Length; i++)
     {
@@ -76,9 +81,28 @@ if (type is "releases-index" or "releases")
         {
             genTemplatePath = args[++i];
         }
+        else if (args[i] == "--url-root" && i + 1 < args.Length)
+        {
+            genUrlRoot = args[++i];
+        }
         else if (!args[i].StartsWith('-'))
         {
-            genPath = args[i];
+            if (type is "version-index" or "timeline-index" or "llms-index" or "indexes")
+            {
+                // Index generators: first positional is input-dir, second is output-dir
+                if (genPath == ".")
+                {
+                    genPath = args[i];
+                }
+                else
+                {
+                    genOutputPath = args[i];
+                }
+            }
+            else
+            {
+                genPath = args[i];
+            }
         }
     }
 
@@ -86,6 +110,10 @@ if (type is "releases-index" or "releases")
     {
         "releases-index" => await GenerateReleasesIndexAsync(genPath),
         "releases" => await GenerateReleasesAsync(genPath, genTemplatePath),
+        "version-index" => await GenerateVersionIndexAsync(genPath, genOutputPath, genUrlRoot),
+        "timeline-index" => await GenerateTimelineIndexAsync(genPath, genOutputPath, genUrlRoot),
+        "llms-index" => await GenerateLlmsIndexAsync(genPath, genOutputPath, genUrlRoot),
+        "indexes" => await GenerateAllIndexesAsync(genPath, genOutputPath, genUrlRoot),
         _ => 1
     };
 }
@@ -344,6 +372,108 @@ async Task<int> GenerateReleasesAsync(string basePath, string? templatePath)
     return 0;
 }
 
+(string InputDir, string OutputDir) PrepareIndexDirs(string inputDir, string? outputDir)
+{
+    var resolvedOutput = outputDir ?? inputDir;
+
+    if (!Directory.Exists(inputDir))
+    {
+        throw new DirectoryNotFoundException($"Input directory not found: {inputDir}");
+    }
+
+    if (inputDir != resolvedOutput && !Directory.Exists(resolvedOutput))
+    {
+        Directory.CreateDirectory(resolvedOutput);
+        Console.Error.WriteLine($"Created output directory: {resolvedOutput}");
+    }
+
+    return (inputDir, resolvedOutput);
+}
+
+async Task<List<MajorReleaseSummary>> LoadSummariesAsync(string inputDir, bool supportedOnly = false)
+{
+    return await ReleaseSummaryLoader.GetReleaseSummariesAsync(inputDir, supportedOnly)
+        ?? throw new InvalidOperationException("Failed to generate release summaries.");
+}
+
+async Task<int> GenerateVersionIndexAsync(string inputDir, string? outputDir, string? urlRoot)
+{
+    var (input, output) = PrepareIndexDirs(inputDir, outputDir);
+
+    if (urlRoot != null) Location.SetUrlRoot(urlRoot);
+
+    Console.Error.WriteLine($"Generating version indexes from {Path.GetFullPath(input)}...");
+
+    var summaries = await LoadSummariesAsync(input);
+    await ReleaseIndexFiles.GenerateAsync(summaries, input, output);
+    await DownloadsIndexFiles.GenerateAsync(summaries, output);
+
+    Console.Error.WriteLine("Version index generation complete.");
+    return 0;
+}
+
+async Task<int> GenerateTimelineIndexAsync(string inputDir, string? outputDir, string? urlRoot)
+{
+    var (input, output) = PrepareIndexDirs(inputDir, outputDir);
+
+    if (urlRoot != null) Location.SetUrlRoot(urlRoot);
+
+    Console.Error.WriteLine($"Generating timeline indexes from {Path.GetFullPath(input)}...");
+
+    var summaries = await LoadSummariesAsync(input);
+    ReleaseHistory history = ReleaseSummaryLoader.GetReleaseCalendar(summaries);
+    ReleaseSummaryLoader.PopulateCveInformation(history, input);
+    await ShipIndexFiles.GenerateAsync(input, output, history, summaries);
+
+    Console.Error.WriteLine("Timeline index generation complete.");
+    return 0;
+}
+
+async Task<int> GenerateLlmsIndexAsync(string inputDir, string? outputDir, string? urlRoot)
+{
+    var (input, output) = PrepareIndexDirs(inputDir, outputDir);
+
+    if (urlRoot != null) Location.SetUrlRoot(urlRoot);
+
+    Console.Error.WriteLine($"Generating llms.json from {Path.GetFullPath(input)}...");
+
+    var summaries = await LoadSummariesAsync(input, supportedOnly: true);
+    ReleaseHistory history = ReleaseSummaryLoader.GetReleaseCalendar(summaries);
+    ReleaseSummaryLoader.PopulateCveInformation(history, input);
+    await LlmsIndexFiles.GenerateAsync(input, output, summaries, history);
+
+    Console.Error.WriteLine("LLMs index generation complete.");
+    return 0;
+}
+
+async Task<int> GenerateAllIndexesAsync(string inputDir, string? outputDir, string? urlRoot)
+{
+    var (input, output) = PrepareIndexDirs(inputDir, outputDir);
+
+    if (urlRoot != null) Location.SetUrlRoot(urlRoot);
+
+    Console.Error.WriteLine($"Generating all indexes from {Path.GetFullPath(input)}...");
+
+    // Load all summaries (version-index and timeline need all; llms needs supported only)
+    var allSummaries = await LoadSummariesAsync(input);
+    ReleaseHistory history = ReleaseSummaryLoader.GetReleaseCalendar(allSummaries);
+    ReleaseSummaryLoader.PopulateCveInformation(history, input);
+
+    // Version indexes
+    await ReleaseIndexFiles.GenerateAsync(allSummaries, input, output);
+    await DownloadsIndexFiles.GenerateAsync(allSummaries, output);
+
+    // Timeline indexes
+    await ShipIndexFiles.GenerateAsync(input, output, history, allSummaries);
+
+    // LLMs index (filter to supported only)
+    var supportedSummaries = allSummaries.Where(s => s.Lifecycle.Supported).ToList();
+    await LlmsIndexFiles.GenerateAsync(input, output, supportedSummaries, history);
+
+    Console.Error.WriteLine("All index generation complete.");
+    return 0;
+}
+
 async Task<int> VerifyReleasesAsync(string basePath, string? version, bool skipHash)
 {
     string scope = version is not null ? $".NET {version}" : "all supported versions";
@@ -371,12 +501,17 @@ static void PrintUsage()
     Console.Error.WriteLine("Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]");
     Console.Error.WriteLine("       dotnet-release generate releases-index [path]");
     Console.Error.WriteLine("       dotnet-release generate releases [path] [--template <file>]");
+    Console.Error.WriteLine("       dotnet-release generate version-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       dotnet-release generate timeline-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       dotnet-release generate llms-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       dotnet-release generate indexes <input-dir> [output-dir] [--url-root <url>]");
     Console.Error.WriteLine("       dotnet-release generate <type> --export-template");
     Console.Error.WriteLine("       dotnet-release verify <type> <version> [path-or-url]");
     Console.Error.WriteLine("       dotnet-release verify releases [version] [path] [--skip-hash]");
     Console.Error.WriteLine("       dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]");
     Console.Error.WriteLine();
-    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, releases-index, releases");
+    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, releases-index, releases,");
+    Console.Error.WriteLine("       version-index, timeline-index, llms-index, indexes");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
     Console.Error.WriteLine("  dotnet-release generate supported-os 10.0");
@@ -388,6 +523,10 @@ static void PrintUsage()
     Console.Error.WriteLine("  dotnet-release generate releases-index ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate releases ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release generate releases --export-template > my-template.md");
+    Console.Error.WriteLine("  dotnet-release generate version-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release generate timeline-index ~/git/core/release-notes /tmp/output");
+    Console.Error.WriteLine("  dotnet-release generate llms-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  dotnet-release generate indexes ~/git/core/release-notes --url-root https://raw.githubusercontent.com/dotnet/core/abc123");
     Console.Error.WriteLine("  dotnet-release verify supported-os 10.0");
     Console.Error.WriteLine("  dotnet-release verify supported-os 10.0 ~/git/core/release-notes");
     Console.Error.WriteLine("  dotnet-release verify os-packages 10.0");

--- a/src/Dotnet.Release/Dotnet.Release.csproj
+++ b/src/Dotnet.Release/Dotnet.Release.csproj
@@ -5,4 +5,8 @@
     <Description>Shared types for .NET release data models</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="Summary\**" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dotnet.Release/Location.cs
+++ b/src/Dotnet.Release/Location.cs
@@ -1,0 +1,26 @@
+namespace Dotnet.Release;
+
+public class Location
+{
+    public static string OfficialBaseUri { get; private set; } = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/";
+
+    public static string GitHubBaseUri { get; private set; } = "https://raw.githubusercontent.com/dotnet/core/refs/heads/release-index/release-notes/";
+
+    public static string MajorReleasesIndexUri { get; private set; } = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json";
+
+    public static void SetUrlRoot(string urlRoot)
+    {
+        if (!urlRoot.EndsWith("/release-notes/"))
+        {
+            if (urlRoot.EndsWith("/"))
+            {
+                urlRoot += "release-notes/";
+            }
+            else
+            {
+                urlRoot += "/release-notes/";
+            }
+        }
+        GitHubBaseUri = urlRoot;
+    }
+}

--- a/src/Dotnet.Release/ReleaseEnums.cs
+++ b/src/Dotnet.Release/ReleaseEnums.cs
@@ -36,8 +36,9 @@ public enum ReleaseType
 
 [Description("Full lifecycle information for a major .NET release")]
 public record Lifecycle(
-    [property: Description("Support duration model (LTS or STS)")]
-    ReleaseType ReleaseType,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Support duration model (LTS or STS), null for feature bands")]
+    ReleaseType? ReleaseType,
 
     [property: Description("Current support phase")]
     SupportPhase Phase,
@@ -48,8 +49,8 @@ public record Lifecycle(
     [property: Description("End of Life date")]
     DateTimeOffset EolDate)
 {
-    [Description("Whether this release is currently supported (not EOL)")]
-    public bool Supported => Phase != SupportPhase.Eol;
+    [Description("Whether this release is currently supported (based on EOL date and lifecycle phase)")]
+    public bool Supported { get; set; } = false;
 }
 
 [Description("Simplified lifecycle for patch releases")]
@@ -75,7 +76,81 @@ public static class ReleaseStability
 {
     public static bool IsStable(SupportPhase phase) => phase is SupportPhase.Active or SupportPhase.Maintenance;
 
+    public static bool IsStable(Lifecycle? lifecycle) => lifecycle != null && IsStable(lifecycle.Phase);
+
     public static bool IsSupported(SupportPhase phase) => phase is not SupportPhase.Eol;
 
+    public static bool IsSupported(Lifecycle? lifecycle, DateTimeOffset? referenceDate = null)
+    {
+        if (lifecycle == null)
+            return false;
+
+        var checkDate = referenceDate ?? DateTimeOffset.UtcNow;
+        return IsStable(lifecycle.Phase) && checkDate < lifecycle.EolDate;
+    }
+
     public static bool IsPreRelease(SupportPhase phase) => phase is SupportPhase.Preview or SupportPhase.GoLive;
+
+    public static string? FindLatestVersion(
+        IEnumerable<(string Version, Lifecycle? Lifecycle)> releases,
+        StringComparer comparer)
+    {
+        return releases
+            .Where(r => IsStable(r.Lifecycle))
+            .OrderByDescending(r => r.Version, comparer)
+            .Select(r => r.Version)
+            .FirstOrDefault();
+    }
+
+    public static string? FindLatestLtsVersion(
+        IEnumerable<(string Version, Lifecycle? Lifecycle)> releases,
+        StringComparer comparer)
+    {
+        return releases
+            .Where(r => r.Lifecycle != null &&
+                       IsStable(r.Lifecycle) &&
+                       r.Lifecycle.ReleaseType == ReleaseType.LTS)
+            .OrderByDescending(r => r.Version, comparer)
+            .Select(r => r.Version)
+            .FirstOrDefault();
+    }
+
+    public static SupportPhase DeterminePhaseFromVersion(string patchVersion)
+    {
+        if (string.IsNullOrEmpty(patchVersion))
+        {
+            return SupportPhase.Preview;
+        }
+
+        var lowerVersion = patchVersion.ToLowerInvariant();
+
+        if (lowerVersion.Contains("preview"))
+        {
+            return SupportPhase.Preview;
+        }
+
+        if (lowerVersion.Contains("-rc"))
+        {
+            return SupportPhase.GoLive;
+        }
+
+        return SupportPhase.Active;
+    }
+
+    public static SupportPhase ComputeEffectivePhase(SupportPhase phase, DateTimeOffset gaDate, DateTimeOffset? referenceDate = null)
+    {
+        var checkDate = referenceDate ?? DateTimeOffset.UtcNow;
+
+        if ((phase == SupportPhase.Preview || phase == SupportPhase.GoLive) && gaDate <= checkDate)
+        {
+            return SupportPhase.Active;
+        }
+
+        if (phase == SupportPhase.Active && gaDate > checkDate)
+        {
+            return SupportPhase.Preview;
+        }
+
+        return phase;
+    }
 }

--- a/src/Dotnet.Release/Summary/MajorReleaseSummary.cs
+++ b/src/Dotnet.Release/Summary/MajorReleaseSummary.cs
@@ -1,0 +1,16 @@
+namespace Dotnet.Release.Summary;
+
+public record MajorReleaseSummary
+(
+    string MajorVersion,
+    string MajorVersionLabel,
+    Lifecycle Lifecycle,
+    IList<SdkBand> SdkBands,
+    IList<PatchReleaseSummary> PatchReleases
+)
+{
+    public ReleaseType? ReleaseType => Lifecycle.ReleaseType;
+    public SupportPhase SupportPhase => Lifecycle.Phase;
+    public DateTimeOffset GaDate => Lifecycle.GaDate;
+    public DateTimeOffset EolDate => Lifecycle.EolDate;
+};

--- a/src/Dotnet.Release/Summary/PatchReleaseSummary.cs
+++ b/src/Dotnet.Release/Summary/PatchReleaseSummary.cs
@@ -1,0 +1,24 @@
+using Dotnet.Release.Releases;
+
+namespace Dotnet.Release.Summary;
+
+public record PatchReleaseSummary
+(
+    string MajorVersion,
+    string PatchVersion,
+    DateOnly ReleaseDate,
+    bool Security,
+    IList<Releases.Cve> CveList,
+    IList<ReleaseComponent> Components
+)
+{
+    public string? ReleaseJsonPath { get; set; }
+    public string? PatchDirPath { get; set; }
+}
+
+public record ReleaseComponent
+(
+    string Name,
+    string Version,
+    string Label
+);

--- a/src/Dotnet.Release/Summary/ReleaseCalendar.cs
+++ b/src/Dotnet.Release/Summary/ReleaseCalendar.cs
@@ -1,0 +1,12 @@
+namespace Dotnet.Release.Summary;
+
+public record ReleaseHistory(Dictionary<string, ReleaseYear> Years);
+
+public record ReleaseYear(string Year, Dictionary<string, ReleaseMonth> Months);
+
+public record ReleaseMonth(string Month, Dictionary<string, ReleaseDay> Days);
+
+public record ReleaseDay(DateOnly Date, string Month, string Day, List<PatchReleaseSummary> Releases)
+{
+    public string? CveJson { get; set; }
+};

--- a/src/Dotnet.Release/Summary/ReleaseSummaryLoader.cs
+++ b/src/Dotnet.Release/Summary/ReleaseSummaryLoader.cs
@@ -1,0 +1,325 @@
+using System.Globalization;
+using System.Text.Json;
+using Dotnet.Release.Graph;
+using Dotnet.Release.Releases;
+
+namespace Dotnet.Release.Summary;
+
+public static class ReleaseSummaryLoader
+{
+    /// <summary>
+    /// Loads release summaries from the release-notes directory.
+    /// </summary>
+    /// <param name="rootDir">Root directory containing release-notes data</param>
+    /// <param name="supportedOnly">When true, skips expensive patch loading for unsupported versions</param>
+    public static async Task<List<MajorReleaseSummary>> GetReleaseSummariesAsync(string rootDir, bool supportedOnly = false)
+    {
+        var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
+
+        // List of major version entries
+        List<MajorReleaseSummary> majorEntries = [];
+
+        // look at all the major version directories
+        foreach (var majorVersionDir in Directory.EnumerateDirectories(rootDir).OrderDescending(numericStringComparer))
+        {
+            // The presence of a releases.json file indicates this is a major version directory
+            var releasesJson = Path.Combine(majorVersionDir, FileNames.Releases);
+            if (!File.Exists(releasesJson))
+            {
+                continue;
+            }
+
+            var majorVersionDirName = Path.GetFileName(majorVersionDir);
+
+            // When supportedOnly is true, check lifecycle status first to avoid expensive patch loading
+            if (supportedOnly)
+            {
+                var quickLifecycle = await LoadLifecycleAsync(majorVersionDir, releasesJson);
+                if (quickLifecycle?.Supported != true)
+                {
+                    continue;
+                }
+            }
+
+            Console.WriteLine($"Processing major version directory: {majorVersionDir}");
+
+            await using var stream = File.OpenRead(releasesJson);
+            var major = await JsonSerializer.DeserializeAsync<MajorReleaseOverview>(stream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview)
+                ?? throw new InvalidOperationException($"Failed to read major release from {releasesJson}");
+
+            var sdkBands = SdkBand.GetSdkBandsForMajorRelease(major);
+
+            // List of patch version entries
+            List<PatchReleaseSummary> patchEntries = [];
+
+            foreach (var release in major.Releases)
+            {
+
+                if (release is null)
+                {
+                    Console.WriteLine($"No release information found; patch.Release is null.");
+                    continue;
+                }
+
+                // Determine the correct path for the patch - previews/RCs are in a different structure
+                string patchDir;
+                if (release.ReleaseVersion.Contains("-preview.") || release.ReleaseVersion.Contains("-rc."))
+                {
+                    // Extract preview/rc number: "10.0.0-preview.1" -> "preview1" or "10.0.0-rc.1" -> "rc1"
+                    var dashIndex = release.ReleaseVersion.IndexOf('-');
+                    if (dashIndex > 0)
+                    {
+                        var suffix = release.ReleaseVersion.Substring(dashIndex + 1); // "preview.1" or "rc.1"
+                        var parts = suffix.Split('.');
+                        if (parts.Length >= 2)
+                        {
+                            var previewOrRc = parts[0]; // "preview" or "rc"
+                            var number = parts[1];       // "1", "2", etc.
+                            var subdir = $"{previewOrRc}{number}"; // "preview1" or "rc1"
+                            patchDir = Path.Combine(majorVersionDir, "preview", subdir);
+                        }
+                        else
+                        {
+                            patchDir = Path.Combine(majorVersionDir, release.ReleaseVersion);
+                        }
+                    }
+                    else
+                    {
+                        patchDir = Path.Combine(majorVersionDir, release.ReleaseVersion);
+                    }
+                }
+                else
+                {
+                    patchDir = Path.Combine(majorVersionDir, release.ReleaseVersion);
+                }
+
+                var patchJson = Path.Combine(patchDir, FileNames.Release);
+                bool patchExists = File.Exists(patchJson);
+
+                var isSecurity = release.Security;
+                List<ReleaseComponent> components = [];
+
+                if (release.Runtime is not null)
+                {
+                    var runtimeVersion = release.Runtime.Version ?? throw new InvalidOperationException($"Runtime version is null in {patchJson}");
+                    components.Add(new ReleaseComponent("Runtime", runtimeVersion, $".NET Runtime {runtimeVersion}"));
+                }
+
+                if (release.AspnetcoreRuntime is not null)
+                {
+                    var aspnetVersion = release.AspnetcoreRuntime.Version ?? throw new InvalidOperationException($"ASP.NET Core version is null in {patchJson}");
+                    components.Add(new ReleaseComponent("ASP.NET Core", aspnetVersion, $".NET ASP.NET Core {aspnetVersion}"));
+                }
+
+                if (release.WindowsDesktop is not null)
+                {
+                    var windowsDesktopVersion = release.WindowsDesktop.Version ?? throw new InvalidOperationException($"Windows Desktop version is null in {patchJson}");
+                    components.Add(new ReleaseComponent("Windows Desktop", windowsDesktopVersion, $".NET Windows Desktop {windowsDesktopVersion}"));
+                }
+
+                foreach (var sdk in release?.Sdks ?? [])
+                {
+                    var version = sdk.Version ?? throw new InvalidOperationException($"SDK version is null in {patchJson}");
+                    var label = $".NET SDK {version}";
+                    components.Add(new ReleaseComponent("SDK", version, label));
+                }
+
+                if (release?.ReleaseVersion == null)
+                {
+                    throw new InvalidOperationException($"Release version is null in {patchJson}");
+                }
+
+                PatchReleaseSummary summary = new(major.ChannelVersion, release.ReleaseVersion, release.ReleaseDate, isSecurity, release.CveList, components)
+                {
+                    ReleaseJsonPath = patchExists ? Path.GetRelativePath(rootDir, patchJson) : null,
+                    PatchDirPath = Directory.Exists(patchDir) ? Path.GetRelativePath(rootDir, patchDir) : null
+                };
+                patchEntries.Add(summary);
+            }
+
+            Console.WriteLine($"Patch releases found for .NET {majorVersionDirName}: {patchEntries.Count}");
+
+            IList<PatchReleaseSummary> patchVersions = patchEntries.Count is 0 ? Array.Empty<PatchReleaseSummary>() : patchEntries;
+
+            // Read lifecycle data from _manifest.json (authoritative source)
+            var manifestPath = Path.Combine(majorVersionDir, FileNames.PartialManifest);
+            PartialManifest? partialManifest = null;
+            if (File.Exists(manifestPath))
+            {
+                try
+                {
+                    var manifestJson = await File.ReadAllTextAsync(manifestPath);
+                    partialManifest = JsonSerializer.Deserialize<PartialManifest>(manifestJson, ReleaseManifestSerializerContext.Default.PartialManifest);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Failed to read {manifestPath}: {ex.Message}");
+                }
+            }
+
+            // Use _manifest.json dates if available, otherwise fall back to releases.json
+            DateTimeOffset gaDate;
+            DateTimeOffset eolDate;
+            ReleaseType releaseType;
+            SupportPhase phase;
+
+            if (partialManifest?.GaDate.HasValue == true && partialManifest?.EolDate.HasValue == true)
+            {
+                gaDate = partialManifest.GaDate.Value;
+                eolDate = partialManifest.EolDate.Value;
+                releaseType = partialManifest.ReleaseType ?? major.ReleaseType;
+                phase = ReleaseStability.ComputeEffectivePhase(
+                    partialManifest.SupportPhase ?? major.SupportPhase,
+                    gaDate);
+            }
+            else
+            {
+                // Fallback: use releases.json data
+                eolDate = new DateTimeOffset(major.EolDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+                releaseType = major.ReleaseType;
+                phase = major.SupportPhase;
+
+                // For GA date, we don't have a good source without _manifest.json
+                // Use MinValue to indicate unknown
+                gaDate = DateTimeOffset.MinValue;
+                Console.WriteLine($"Warning: {majorVersionDirName} - No _manifest.json found, GA date unknown");
+            }
+
+            // Create Lifecycle object with all lifecycle information
+            var lifecycle = new Lifecycle(releaseType, phase, gaDate, eolDate);
+            lifecycle.Supported = ReleaseStability.IsSupported(lifecycle);
+
+            // Use label from _manifest.json if available, otherwise default to ".NET {version}"
+            var versionLabel = partialManifest?.Label ?? $".NET {major.ChannelVersion}";
+
+            MajorReleaseSummary majorSummary = new MajorReleaseSummary(
+                major.ChannelVersion,
+                versionLabel,
+                lifecycle,
+                sdkBands,
+                patchVersions
+            );
+            majorEntries.Add(majorSummary);
+        }
+
+        return majorEntries;
+    }
+
+    public static ReleaseHistory GetReleaseCalendar(List<MajorReleaseSummary> majorReleases)
+    {
+        var years = new Dictionary<string, ReleaseYear>();
+        foreach (var major in majorReleases)
+        {
+            foreach (var patch in major.PatchReleases)
+            {
+                var patchYear = patch.ReleaseDate.Year.ToString();
+                var patchMonth = patch.ReleaseDate.Month.ToString("D2");
+                var patchDay = patch.ReleaseDate.Day.ToString("D2");
+
+                if (!years.TryGetValue(patchYear, out var releaseYear))
+                {
+                    releaseYear = new ReleaseYear(patchYear, []);
+                    years[patchYear] = releaseYear;
+                }
+
+                if (!releaseYear.Months.TryGetValue(patchMonth, out var releaseMonth))
+                {
+                    releaseMonth = new ReleaseMonth(patchMonth, []);
+                    releaseYear.Months[patchMonth] = releaseMonth;
+                }
+
+                if (!releaseMonth.Days.TryGetValue(patchDay, out var releaseDay))
+                {
+                    releaseDay = new ReleaseDay(
+                        new DateOnly(patch.ReleaseDate.Year, patch.ReleaseDate.Month, patch.ReleaseDate.Day),
+                        patchMonth,
+                        patchDay,
+                        []);
+                    releaseMonth.Days[patchDay] = releaseDay;
+                }
+
+                releaseDay.Releases.Add(patch);
+            }
+        }
+
+        return new ReleaseHistory(years);
+    }
+
+    public static void PopulateCveInformation(ReleaseHistory releaseHistory, string rootDir)
+    {
+        var historyDir = Path.Combine(rootDir, FileNames.Directories.Timeline);
+        if (!Directory.Exists(historyDir))
+        {
+            return;
+        }
+
+        foreach (var year in releaseHistory.Years.Values)
+        {
+            foreach (var month in year.Months.Values)
+            {
+                foreach (var day in month.Days.Values)
+                {
+                    var relativePath = Path.Combine(year.Year, month.Month, FileNames.Cve);
+                    var cveJsonPath = Path.Combine(historyDir, relativePath);
+                    if (File.Exists(cveJsonPath))
+                    {
+                        day.CveJson = relativePath;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads just the lifecycle information for a major version (fast path for supportedOnly filtering).
+    /// </summary>
+    private static async Task<Lifecycle?> LoadLifecycleAsync(string majorVersionDir, string releasesJsonPath)
+    {
+        // Try _manifest.json first (authoritative source for lifecycle data)
+        var manifestPath = Path.Combine(majorVersionDir, FileNames.PartialManifest);
+        if (File.Exists(manifestPath))
+        {
+            try
+            {
+                var manifestJson = await File.ReadAllTextAsync(manifestPath);
+                var partialManifest = JsonSerializer.Deserialize<PartialManifest>(manifestJson, ReleaseManifestSerializerContext.Default.PartialManifest);
+
+                if (partialManifest != null)
+                {
+                    var lifecycle = new Lifecycle(
+                        partialManifest.ReleaseType ?? ReleaseType.STS,
+                        partialManifest.SupportPhase ?? SupportPhase.Eol,
+                        partialManifest.GaDate ?? DateTimeOffset.MinValue,
+                        partialManifest.EolDate ?? DateTimeOffset.MaxValue);
+
+                    lifecycle.Supported = partialManifest.Supported ?? ReleaseStability.IsSupported(lifecycle);
+                    return lifecycle;
+                }
+            }
+            catch
+            {
+                // Fall through to releases.json fallback
+            }
+        }
+
+        // Fallback: read minimal data from releases.json
+        try
+        {
+            await using var stream = File.OpenRead(releasesJsonPath);
+            var major = await JsonSerializer.DeserializeAsync<MajorReleaseOverview>(stream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
+            if (major != null)
+            {
+                var eolDate = new DateTimeOffset(major.EolDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+                var lifecycle = new Lifecycle(major.ReleaseType, major.SupportPhase, DateTimeOffset.MinValue, eolDate);
+                lifecycle.Supported = ReleaseStability.IsSupported(lifecycle);
+                return lifecycle;
+            }
+        }
+        catch
+        {
+            // Unable to determine lifecycle
+        }
+
+        return null;
+    }
+}

--- a/src/Dotnet.Release/Summary/SdkBand.cs
+++ b/src/Dotnet.Release/Summary/SdkBand.cs
@@ -1,0 +1,50 @@
+using Dotnet.Release.Releases;
+
+namespace Dotnet.Release.Summary;
+
+public record SdkBand(string Version, string Label)
+{
+    public SupportPhase SupportPhase { get; set; }
+    public DateOnly LatestReleaseDate { get; set; }
+
+    public static IList<SdkBand> GetSdkBandsForMajorRelease(MajorReleaseOverview major)
+    {
+        var version = major.ChannelVersion;
+        var supportPhase = major.SupportPhase;
+        var supported = supportPhase is SupportPhase.Active or SupportPhase.Maintenance or SupportPhase.Preview;
+        var eolDate = major.EolDate;
+        var releaseType = major.ReleaseType;
+        var latestReleaseDate = major.LatestReleaseDate;
+        var bands = new Dictionary<string, SdkBand>(StringComparer.Ordinal);
+        bool latest = true;
+
+        foreach (var release in major.Releases)
+        {
+            if (release.Sdks is null)
+            {
+                continue;
+            }
+
+            var date = release.ReleaseDate;
+            foreach (var sdk in release.Sdks)
+            {
+                var key = sdk.Version[..5];
+                if (!bands.ContainsKey(key))
+                {
+                    bands.Add(key.ToString(), new SdkBand(sdk.Version, $".NET SDK {key}xx")
+                    {
+                        SupportPhase = supported && date == latestReleaseDate ? supportPhase : SupportPhase.Eol,
+                        LatestReleaseDate = date
+                    });
+                }
+
+                if (latest)
+                {
+                    latest = false;
+                }
+            }
+        }
+
+        return [.. bands.Values];
+    }
+}


### PR DESCRIPTION
Ports the three release-index generator tools (VersionIndex, ShipIndex, LlmsIndex) from distroessed into this repo, merged as subcommands of `dotnet-release generate`.

## New subcommands

| Command | Description |
|---|---|
| `generate version-index <dir> [out] [--url-root <url>]` | Root + major + patch version indexes, downloads directories, manifests |
| `generate timeline-index <dir> [out] [--url-root <url>]` | Chronological year/month timeline indexes with CVE data |
| `generate llms-index <dir> [out] [--url-root <url>]` | AI-optimized `llms.json` for LLM consumption |
| `generate indexes <dir> [out] [--url-root <url>]` | Runs all three generators (shared data loading) |

## Structure

- **`Dotnet.Release.IndexGenerator`** — new library project with all generator logic (~3,200 lines across 13 files)
- **`Dotnet.Release/Summary/`** — data loading layer that reads release-notes directories into `MajorReleaseSummary` / `PatchReleaseSummary` / `ReleaseCalendar` records
- **`Dotnet.Release/Location.cs`** — static URL root management for `--url-root` support

## Changes to existing code

- `Lifecycle.ReleaseType` made nullable (`ReleaseType?`) to match source data
- `Lifecycle.Supported` made settable (was computed from Phase)
- `ReleaseStability` gained `FindLatestVersion`, `FindLatestLtsVersion`, `DeterminePhaseFromVersion`
- `PatchReleaseOverview` gained `Sdks` property
- `HistoryYearIndex.cs` gained `HistoryMonthEntry` record
- Graph types extended: `IndexTitles`, `LinkTitles`, HAL helpers, manifest/LLMs types
- Serializer contexts updated for new types

## Testing

Tested against `~/git/core/release-notes` — generates 398 JSON files successfully including root index, per-version indexes, timeline hierarchy, downloads directories, and llms.json.