### PR TITLE
Use release-index branch for supported-os tooling

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -134,7 +134,7 @@ if (args.Length < 3 || !decimal.TryParse(args[2], out _))
 }
 
 string version = args[2];
-string basePath = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
+string basePath = Location.GitHubBaseUri;
 string? templatePath = null;
 
 // Parse remaining args
@@ -171,12 +171,36 @@ switch (type)
 
 async Task<int> GenerateSupportedOsAsync(IAdaptivePath path, string version, HttpClient client, string? templatePath)
 {
-    string jsonPath = path.Combine(version, "supported-os.json");
+    string jsonPath = path.Combine(version, FileNames.SupportedOs);
     Console.Error.WriteLine($"Reading {jsonPath}...");
 
     using var stream = await path.GetStreamAsync(jsonPath);
     var matrix = await JsonSerializer.DeserializeAsync(stream, SupportedOSMatrixSerializerContext.Default.SupportedOSMatrix)
         ?? throw new InvalidOperationException("Failed to deserialize supported-os.json");
+
+    // Fetch release metadata for support phase and release type
+    string? supportPhase = null;
+    string? releaseType = null;
+
+    string releasesPath = path.Combine(version, FileNames.Releases);
+    Console.Error.WriteLine($"Reading {releasesPath}...");
+
+    try
+    {
+        using var releasesStream = await path.GetStreamAsync(releasesPath);
+        var overview = await JsonSerializer.DeserializeAsync(releasesStream, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
+
+        if (overview is not null)
+        {
+            supportPhase = overview.SupportPhase.ToDisplayName();
+            releaseType = overview.ReleaseType.ToDisplayName();
+            Console.Error.WriteLine($"Release status: {supportPhase}, {releaseType}");
+        }
+    }
+    catch (Exception ex) when (ex is HttpRequestException or FileNotFoundException)
+    {
+        Console.Error.WriteLine($"Could not read releases.json: {ex.Message}");
+    }
 
     TextWriter output;
     string? outputPath = null;
@@ -191,7 +215,7 @@ async Task<int> GenerateSupportedOsAsync(IAdaptivePath path, string version, Htt
         output = Console.Out;
     }
 
-    await SupportedOsGenerator.GenerateAsync(matrix, output, version, client, templatePath: templatePath);
+    await SupportedOsGenerator.GenerateAsync(matrix, output, version, client, supportPhase: supportPhase, releaseType: releaseType, templatePath: templatePath);
 
     if (outputPath is not null)
     {
@@ -746,7 +770,7 @@ async Task<int> HandleVerifyAsync(string[] args)
     }
 
     string version = args[2];
-    string basePath = args.Length > 3 && !args[3].StartsWith('-') ? args[3] : "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
+    string basePath = args.Length > 3 && !args[3].StartsWith('-') ? args[3] : Location.GitHubBaseUri;
 
     using var client = new HttpClient();
     var path = AdaptivePath.Create(basePath, client);

--- a/src/Dotnet.Release.Tools/ReleasesGenerator.cs
+++ b/src/Dotnet.Release.Tools/ReleasesGenerator.cs
@@ -199,13 +199,5 @@ public static class ReleasesGenerator
 
     static string FormatDate(DateOnly date) => date.ToString("MMMM d, yyyy");
 
-    static string FormatSupportPhase(SupportPhase phase) => phase switch
-    {
-        SupportPhase.Preview => "Preview",
-        SupportPhase.GoLive => "Go Live",
-        SupportPhase.Active => "Active",
-        SupportPhase.Maintenance => "Maintenance",
-        SupportPhase.Eol => "End of life",
-        _ => phase.ToString()
-    };
+    static string FormatSupportPhase(SupportPhase phase) => phase.ToDisplayName();
 }

--- a/src/Dotnet.Release.Tools/ReleasesIndexGenerator.cs
+++ b/src/Dotnet.Release.Tools/ReleasesIndexGenerator.cs
@@ -99,7 +99,7 @@ public static class ReleasesIndexGenerator
         return ".NET Core";
     }
 
-    internal static string FormatSupportPhase(SupportPhase phase) => phase switch
+    public static string FormatSupportPhase(SupportPhase phase) => phase switch
     {
         SupportPhase.Preview => "preview",
         SupportPhase.GoLive => "go-live",
@@ -109,7 +109,7 @@ public static class ReleasesIndexGenerator
         _ => phase.ToString().ToLowerInvariant()
     };
 
-    internal static string FormatReleaseType(ReleaseType type) => type switch
+    public static string FormatReleaseType(ReleaseType type) => type switch
     {
         ReleaseType.LTS => "lts",
         ReleaseType.STS => "sts",

--- a/src/Dotnet.Release/ReleaseEnums.cs
+++ b/src/Dotnet.Release/ReleaseEnums.cs
@@ -72,6 +72,26 @@ public enum ProductComponent
     SDK
 }
 
+public static class ReleaseDisplayNames
+{
+    public static string ToDisplayName(this SupportPhase phase) => phase switch
+    {
+        SupportPhase.Preview => "Preview",
+        SupportPhase.GoLive => "Go Live",
+        SupportPhase.Active => "Active",
+        SupportPhase.Maintenance => "Maintenance",
+        SupportPhase.Eol => "End of Life",
+        _ => phase.ToString()
+    };
+
+    public static string ToDisplayName(this ReleaseType type) => type switch
+    {
+        ReleaseType.LTS => "LTS",
+        ReleaseType.STS => "STS",
+        _ => type.ToString()
+    };
+}
+
 public static class ReleaseStability
 {
     public static bool IsStable(SupportPhase phase) => phase is SupportPhase.Active or SupportPhase.Maintenance;


### PR DESCRIPTION
## Summary

Switch supported-os generate and verify commands to use the `release-index` branch (via `Location.GitHubBaseUri`) as the default data source. This branch has proper release metadata (`releases.json`) with `SupportPhase` and `ReleaseType`, eliminating the "Unknown" status in generated markdown.

## Changes

- **Default URL**: Both generate and verify commands now default to `Location.GitHubBaseUri` (release-index branch) instead of hardcoded `main` branch URL
- **Release status resolution**: `GenerateSupportedOsAsync` fetches `releases.json` to get `SupportPhase` and `ReleaseType`, passing them to the markdown generator (gracefully handles missing data)
- **Display name formatting**: Added `ToDisplayName()` extension methods on `SupportPhase` and `ReleaseType` in `Dotnet.Release` so all tools get proper casing (LTS, STS, Preview, Active, etc.)
- **Version bump**: Dotnet.Release.Tools 0.6.0 → 0.7.0

## Validation

Tested against `dotnet/core` `fix-windows-server-2012-support` branch:
- 8.0 → Active, LTS ✓
- 9.0 → Active, STS ✓
- 10.0 → Active, LTS ✓

No "Unknown" in any generated output.