### PR TITLE
Bump Dotnet.Release.Tools to 1.1.0

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->


### PR DESCRIPTION
Resets versioning above the stale 1.0.0 package so that default tool install (`dotnet tool install -g Dotnet.Release.Tools`) picks up the latest build instead of the old 1.0.0 which only had `supported-os` and `os-packages` commands.

After merge, the publish workflow will build AOT packages for all RIDs and push 1.1.0 to GitHub Packages.