### PR TITLE
Add VMR commit references to generate changes output

### DIFF
--- a/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
@@ -16,13 +16,14 @@ public partial class ChangeCollector(HttpClient httpClient)
     /// Gets the PRs merged between two commits in a repo via the GitHub compare API.
     /// Returns a list of (PR number, PR title, PR URL, merge commit SHA).
     /// </summary>
-    public async Task<List<PullRequestInfo>> GetMergedPullRequestsAsync(
+    public async Task<CompareResult> GetMergedPullRequestsAsync(
         string org, string repo, string baseSha, string headSha)
     {
         var prs = new Dictionary<int, PullRequestInfo>();
 
         // Use compare API to get commits in range
         var commits = await GetCompareCommitsAsync(org, repo, baseSha, headSha);
+        var orderedShas = commits.Select(c => c.Sha).ToList();
 
         foreach (var commit in commits)
         {
@@ -40,7 +41,7 @@ public partial class ChangeCollector(HttpClient httpClient)
             }
         }
 
-        return [.. prs.Values];
+        return new CompareResult([.. prs.Values], orderedShas);
     }
 
     /// <summary>
@@ -192,6 +193,11 @@ public partial class ChangeCollector(HttpClient httpClient)
 /// A PR discovered from the compare API commit range.
 /// </summary>
 public record PullRequestInfo(int Number, string Title, string Url, string MergeCommitSha, IList<string>? Labels = null);
+
+/// <summary>
+/// Result of comparing two commits: extracted PRs and the full ordered commit SHA list.
+/// </summary>
+public record CompareResult(List<PullRequestInfo> PullRequests, List<string> CommitShas);
 
 internal record CompareCommit(string Sha, string Message);
 

--- a/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
@@ -33,6 +33,7 @@ public class ChangesGenerator(HttpClient httpClient)
 
         var changes = new List<ChangeEntry>();
         var commits = new Dictionary<string, CommitEntry>();
+        var repoCommitOrder = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var diff in diffs)
         {
@@ -44,16 +45,20 @@ public class ChangesGenerator(HttpClient httpClient)
 
             Console.Error.WriteLine($"  {diff.Path}: comparing {diff.BaseSha[..7]}...{diff.HeadSha[..7]}");
 
-            List<PullRequestInfo> prs;
+            CompareResult compareResult;
             try
             {
-                prs = await _collector.GetMergedPullRequestsAsync(diff.Org, diff.Repo, diff.BaseSha, diff.HeadSha);
+                compareResult = await _collector.GetMergedPullRequestsAsync(diff.Org, diff.Repo, diff.BaseSha, diff.HeadSha);
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"    Warning: failed to collect PRs for {diff.Org}/{diff.Repo}: {ex.Message}");
                 continue;
             }
+
+            var prs = compareResult.PullRequests;
+            repoCommitOrder[diff.Path] = EnsureChronologicalOrder(
+                compareResult.CommitShas, diff.HeadSha, diff.Path);
 
             Console.Error.WriteLine($"    Found {prs.Count} PRs");
 
@@ -108,12 +113,52 @@ public class ChangesGenerator(HttpClient httpClient)
             }
         }
 
+        // Map source-repo commits to VMR (dotnet/dotnet) commits via manifest diffs
+        Console.Error.WriteLine("Mapping source commits to VMR commits...");
+        var vmrMapping = await VmrCommitMapper.MapAsync(
+            repoPath, baseRef, headRef, diffs, commits, repoCommitOrder);
+        VmrCommitMapper.Apply(vmrMapping, changes, commits, branch);
+        Console.Error.WriteLine($"Mapped {vmrMapping.Count} of {commits.Count} source commit(s) to VMR.");
+
         return new ChangeRecords(
             ReleaseVersion: releaseVersion,
             ReleaseDate: releaseDate,
             Changes: changes,
             Commits: commits
         );
+    }
+
+    /// <summary>
+    /// Validates that the compare API commit list is in chronological order (oldest first).
+    /// The head SHA should be the last entry. If reversed, corrects the order.
+    /// Returns an empty list if ordering cannot be determined.
+    /// </summary>
+    private static List<string> EnsureChronologicalOrder(
+        List<string> commitShas, string headSha, string repoPath)
+    {
+        if (commitShas.Count == 0)
+        {
+            return commitShas;
+        }
+
+        // Chronological: head SHA is at the end
+        if (commitShas[^1].Equals(headSha, StringComparison.OrdinalIgnoreCase))
+        {
+            return commitShas;
+        }
+
+        // Reverse chronological: head SHA is at the beginning — reverse to fix
+        if (commitShas[0].Equals(headSha, StringComparison.OrdinalIgnoreCase))
+        {
+            commitShas.Reverse();
+            return commitShas;
+        }
+
+        // Cannot determine order — return empty to skip ordering-dependent mapping
+        Console.Error.WriteLine(
+            $"    Warning: could not verify commit ordering for {repoPath}; " +
+            $"VMR mapping may be incomplete for multi-codeflow ranges");
+        return [];
     }
 
     /// <summary>

--- a/src/Dotnet.Release.ChangesHandler/VmrCommitMapper.cs
+++ b/src/Dotnet.Release.ChangesHandler/VmrCommitMapper.cs
@@ -1,0 +1,197 @@
+using Dotnet.Release.Changes;
+
+namespace Dotnet.Release.ChangesHandler;
+
+/// <summary>
+/// Maps source-repo commit SHAs to VMR (dotnet/dotnet) commit SHAs by diffing
+/// source-manifest.json at each manifest-changing VMR commit to find which
+/// codeflow introduced each child-repo SHA range.
+/// </summary>
+public static class VmrCommitMapper
+{
+    /// <summary>
+    /// For each source-repo commit, finds the VMR commit that brought it into dotnet/dotnet.
+    /// Uses source-manifest.json diffs to build authoritative codeflow ranges, then
+    /// partitions source commits using the compare API's commit ordering.
+    /// </summary>
+    public static async Task<Dictionary<string, string>> MapAsync(
+        string repoPath,
+        string baseRef,
+        string headRef,
+        List<RepoDiff> diffs,
+        IDictionary<string, CommitEntry> sourceCommits,
+        Dictionary<string, List<string>> repoCommitOrder)
+    {
+        // Get VMR commits that changed src/source-manifest.json, in chronological order
+        var vmrManifestCommits = await GetManifestChangingCommitsAsync(repoPath, baseRef, headRef);
+        if (vmrManifestCommits.Count == 0)
+        {
+            return new();
+        }
+
+        Console.Error.WriteLine($"  Found {vmrManifestCommits.Count} manifest-changing VMR commit(s) in range.");
+
+        // Diff manifest at each VMR commit to build per-repo codeflow ranges
+        var codeflows = await BuildCodeflowRangesAsync(repoPath, vmrManifestCommits);
+        if (codeflows.Count == 0)
+        {
+            return new();
+        }
+
+        // Map source commits to VMR commits using codeflow ranges + commit ordering
+        return MapSourceCommits(sourceCommits, codeflows, repoCommitOrder);
+    }
+
+    /// <summary>
+    /// Applies the VMR commit mapping to the change entries and commits dictionary.
+    /// </summary>
+    public static void Apply(
+        Dictionary<string, string> vmrMapping,
+        List<ChangeEntry> changes,
+        IDictionary<string, CommitEntry> commits,
+        string branch)
+    {
+        foreach (var (sourceKey, vmrHash) in vmrMapping)
+        {
+            var vmrKey = $"dotnet@{vmrHash[..7]}";
+
+            if (!commits.ContainsKey(vmrKey))
+            {
+                commits[vmrKey] = new CommitEntry(
+                    Repo: "dotnet",
+                    Branch: branch,
+                    Hash: vmrHash,
+                    Org: "dotnet",
+                    Url: $"https://github.com/dotnet/dotnet/commit/{vmrHash}.diff"
+                );
+            }
+
+            for (int i = 0; i < changes.Count; i++)
+            {
+                if (changes[i].Commit == sourceKey && changes[i].DotnetCommit is null)
+                {
+                    changes[i] = changes[i] with { DotnetCommit = vmrKey };
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets VMR commits that changed src/source-manifest.json, in chronological order.
+    /// </summary>
+    private static async Task<List<string>> GetManifestChangingCommitsAsync(
+        string repoPath, string baseRef, string headRef)
+    {
+        var result = await GitHelpers.RunGitAsync(repoPath,
+            ["log", "--format=%H", "--reverse", $"{baseRef}..{headRef}", "--", "src/source-manifest.json"]);
+
+        if (result.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"  Warning: could not get VMR manifest log: {result.Error}");
+            return [];
+        }
+
+        return [.. result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries)];
+    }
+
+    /// <summary>
+    /// For each manifest-changing VMR commit, diffs source-manifest.json at that commit
+    /// vs its parent to find which repos changed and what child-repo SHA was introduced.
+    /// </summary>
+    private static async Task<List<CodeflowRange>> BuildCodeflowRangesAsync(
+        string repoPath, List<string> vmrCommits)
+    {
+        var ranges = new List<CodeflowRange>();
+
+        foreach (var vmrCommit in vmrCommits)
+        {
+            try
+            {
+                var headManifest = await ManifestDiffer.LoadFromGitAsync(repoPath, vmrCommit);
+                var baseManifest = await ManifestDiffer.LoadFromGitAsync(repoPath, $"{vmrCommit}~1");
+                var diffs = ManifestDiffer.Diff(baseManifest, headManifest);
+
+                foreach (var diff in diffs)
+                {
+                    Console.Error.WriteLine(
+                        $"    {diff.Path}: codeflow at VMR commit {vmrCommit[..7]} " +
+                        $"({diff.BaseSha[..7]}→{diff.HeadSha[..7]})");
+                    ranges.Add(new CodeflowRange(vmrCommit, diff.Path, diff.HeadSha));
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"    Warning: could not diff manifest at {vmrCommit[..7]}: {ex.Message}");
+            }
+        }
+
+        return ranges;
+    }
+
+    /// <summary>
+    /// Maps source-repo commits to VMR commits using codeflow ranges and commit ordering.
+    /// For repos with a single codeflow, all commits map directly.
+    /// For repos with multiple codeflows, uses the compare API commit order to partition.
+    /// </summary>
+    private static Dictionary<string, string> MapSourceCommits(
+        IDictionary<string, CommitEntry> sourceCommits,
+        List<CodeflowRange> codeflows,
+        Dictionary<string, List<string>> repoCommitOrder)
+    {
+        var mapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var codeflowsByRepo = codeflows
+            .GroupBy(c => c.RepoPath, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (commitKey, entry) in sourceCommits)
+        {
+            if (!codeflowsByRepo.TryGetValue(entry.Repo, out var repoCodeflows))
+            {
+                continue;
+            }
+
+            if (repoCodeflows.Count == 1)
+            {
+                // Single codeflow for this repo — all source commits map to it
+                mapping[commitKey] = repoCodeflows[0].VmrCommitHash;
+                continue;
+            }
+
+            // Multiple codeflows — use commit ordering to find which codeflow covers this commit
+            if (!repoCommitOrder.TryGetValue(entry.Repo, out var orderedShas))
+            {
+                continue;
+            }
+
+            // Build position index: commit SHA → position in chronological order
+            var positions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < orderedShas.Count; i++)
+            {
+                positions[orderedShas[i]] = i;
+            }
+
+            if (!positions.TryGetValue(entry.Hash, out var commitPos))
+            {
+                continue;
+            }
+
+            // Find the first codeflow boundary that is at or after this commit's position
+            var match = repoCodeflows
+                .Where(cf => positions.ContainsKey(cf.NewChildSha))
+                .Select(cf => (cf.VmrCommitHash, Position: positions[cf.NewChildSha]))
+                .OrderBy(b => b.Position)
+                .FirstOrDefault(b => b.Position >= commitPos);
+
+            if (match != default)
+            {
+                mapping[commitKey] = match.VmrCommitHash;
+            }
+        }
+
+        return mapping;
+    }
+}
+
+internal record CodeflowRange(string VmrCommitHash, string RepoPath, string NewChildSha);

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->


### PR DESCRIPTION
## Summary

Map source-repo commits to their corresponding `dotnet/dotnet` VMR commits using `source-manifest.json` diffs — the authoritative codeflow artifact. Populates the existing `dotnet_commit` field on change entries for **all** changes, not just security changes.

## How it works

`VmrCommitMapper` walks VMR commits that changed `src/source-manifest.json` between `--base` and `--head`, diffs the manifest at each to find per-repo codeflow ranges (`oldChildSha` → `newChildSha`), then assigns each source-repo PR to the codeflow that covers it.

- **Single codeflow per repo** (common case): all source commits map directly
- **Multiple codeflows**: uses compare API commit ordering to partition correctly
- **Ordering enforcement**: validates the compare API returns chronological order using the head SHA as anchor; auto-corrects if reversed

## Changes

- **New**: `VmrCommitMapper.cs` — manifest-based source-to-VMR commit mapping
- **Modified**: `ChangeCollector.cs` — returns `CompareResult` exposing ordered commit SHAs
- **Modified**: `ChangesGenerator.cs` — wires up mapping + ordering validation
- **Bump**: `Dotnet.Release.Tools` 1.1.0 → 1.2.0

## Example output

```json
{
  "changes": [
    {
      "id": 16526,
      "repo": "arcade",
      "title": "Change PackageReference to PackageDownload",
      "url": "https://github.com/dotnet/arcade/pull/16526",
      "commit": "arcade@7db333e",
      "is_security": false,
      "dotnet_commit": "dotnet@b4e9f1a"
    }
  ],
  "commits": {
    "arcade@7db333e": { "repo": "arcade", "hash": "7db333e...", ... },
    "dotnet@b4e9f1a": { "repo": "dotnet", "hash": "b4e9f1a...", ... }
  }
}
```

Closes #35