### PR TITLE
Simplify commit field: commit → VMR, local_repo_commit → source repo

### DIFF
--- a/src/Dotnet.Release.Changes/ChangeRecords.cs
+++ b/src/Dotnet.Release.Changes/ChangeRecords.cs
@@ -33,7 +33,7 @@ public record ChangeEntry(
     [property: Description("Public GitHub PR URL; empty string if PR is non-public.")]
     string Url,
 
-    [property: Description("Key into the top-level commits dictionary (child repo commit).")]
+    [property: Description("Key into the top-level commits dictionary (dotnet/dotnet VMR commit).")]
     string Commit,
 
     [property: Description("True if this is a security change.")]
@@ -51,8 +51,12 @@ public record ChangeEntry(
         JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? CveId = null,
 
-    [property: Description("Key into the top-level commits dictionary (dotnet/dotnet commit)."),
+    [property: Description("Key into the top-level commits dictionary (source-repo commit, e.g. runtime, aspnetcore)."),
         JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? LocalRepoCommit = null,
+
+    [property: Description("Internal staging field for VMR commit mapping; never serialized."),
+        JsonIgnore]
     string? DotnetCommit = null,
 
     [property: Description("GitHub PR labels from the child repo."),

--- a/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
@@ -129,6 +129,36 @@ public class ChangesGenerator(HttpClient httpClient)
     }
 
     /// <summary>
+    /// Collapses the two-commit representation so that Commit references the VMR commit
+    /// and LocalRepoCommit references the source-repo commit.
+    /// </summary>
+    public static ChangeRecords CollapseToVmrCommits(ChangeRecords records)
+    {
+        var newChanges = new List<ChangeEntry>(records.Changes.Count);
+
+        foreach (var change in records.Changes)
+        {
+            if (change.DotnetCommit is not null)
+            {
+                // VMR mapping exists: commit → VMR, local_repo_commit → source
+                newChanges.Add(change with
+                {
+                    LocalRepoCommit = change.Commit,
+                    Commit = change.DotnetCommit,
+                    DotnetCommit = null
+                });
+            }
+            else
+            {
+                // No VMR mapping: keep source-repo commit as-is
+                newChanges.Add(change);
+            }
+        }
+
+        return new ChangeRecords(records.ReleaseVersion, records.ReleaseDate, newChanges, records.Commits);
+    }
+
+    /// <summary>
     /// Validates that the compare API commit list is in chronological order (oldest first).
     /// The head SHA should be the last entry. If reversed, corrects the order.
     /// Returns an empty list if ordering cannot be determined.
@@ -185,7 +215,7 @@ public class ChangesGenerator(HttpClient httpClient)
 
             // Collect only commits referenced by this repo's changes
             var repoCommitKeys = repoChanges.Select(c => c.Commit)
-                .Concat(repoChanges.Where(c => c.DotnetCommit is not null).Select(c => c.DotnetCommit!))
+                .Concat(repoChanges.Where(c => c.LocalRepoCommit is not null).Select(c => c.LocalRepoCommit!))
                 .Distinct()
                 .ToHashSet();
             var repoCommits = records.Commits

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -624,6 +624,10 @@ async Task<int> HandleGenerateChangesAsync(string[] args)
         records = await CveCrossReference.ApplyAsync(records, cveRepoPath, repoPath, baseRef, headRef);
     }
 
+    // Collapse to VMR-only commits: commit = dotnet_commit, drop source-repo entries
+    records = ChangesGenerator.CollapseToVmrCommits(records);
+    Console.Error.WriteLine($"Collapsed to {records.Commits.Count} VMR commit(s).");
+
     // Write output
     var writeAction = jsonl
         ? (Action<ChangeRecords, TextWriter>)ChangesGenerator.WriteJsonl


### PR DESCRIPTION
## Summary

Breaking schema change to `changes.json`: the `commit` field now references the VMR (`dotnet/dotnet`) commit, and a new `local_repo_commit` field preserves the source-repo commit.

## Before (v1.2.0)

```json
{
  "id": 123613,
  "repo": "runtime",
  "title": "...",
  "url": "https://github.com/dotnet/runtime/pull/123613",
  "commit": "runtime@10957a8",
  "dotnet_commit": "dotnet@69a3a61",
  "is_security": false
}
```

## After (v2.0.0)

```json
{
  "id": 123613,
  "repo": "runtime",
  "title": "...",
  "url": "https://github.com/dotnet/runtime/pull/123613",
  "commit": "dotnet@69a3a61",
  "is_security": false,
  "local_repo_commit": "runtime@10957a8"
}
```

- `commit` → VMR commit (the product-level view of what shipped)
- `local_repo_commit` → source-repo commit (direct `.diff` access)
- `url` → source-repo PR (code change, discussion, reviews)
- `dotnet_commit` removed from output (`[JsonIgnore]` internal staging field)
- Both commit types remain in the `commits{}` dictionary

## Implementation

Uses a deferred collapse approach — all internal processing (VMR mapping, CVE cross-reference) works with the existing two-field representation. A final `CollapseToVmrCommits` step swaps the fields before serialization. Zero changes to `VmrCommitMapper` or `CveCrossReference`.

Bumps `Dotnet.Release.Tools` to 2.0.0 (breaking schema change).

Closes #37, closes #38