### PR TITLE
Use commit key as globally unique string ID in changes.json

### DIFF
--- a/src/Dotnet.Release.Changes/ChangeRecords.cs
+++ b/src/Dotnet.Release.Changes/ChangeRecords.cs
@@ -21,8 +21,8 @@ public record ChangeRecords(
 
 [Description("An externally visible change artifact (PR or commit-backed security change).")]
 public record ChangeEntry(
-    [property: Description("GitHub PR number; 0 if no public PR exists.")]
-    int Id,
+    [property: Description("Globally unique change identifier (commit key, e.g. \"runtime@c5d5be4\").")]
+    string Id,
 
     [property: Description("Short repository name, e.g. \"runtime\".")]
     string Repo,

--- a/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangesGenerator.cs
@@ -101,7 +101,7 @@ public class ChangesGenerator(HttpClient httpClient)
                 labelMap?.TryGetValue(pr.Number, out labels);
 
                 changes.Add(new ChangeEntry(
-                    Id: pr.Number,
+                    Id: commitKey,
                     Repo: diff.Path,
                     Title: pr.Title,
                     Url: pr.Url,

--- a/src/Dotnet.Release.ChangesHandler/CveCrossReference.cs
+++ b/src/Dotnet.Release.ChangesHandler/CveCrossReference.cs
@@ -327,7 +327,7 @@ public static class CveCrossReference
 
             // Security PRs are non-public; CVE data is the source of truth
             newChanges.Add(new ChangeEntry(
-                Id: 0,
+                Id: dotnetCommitKey,
                 Repo: "dotnet",
                 Title: "",
                 Url: "",

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->


### PR DESCRIPTION
## Summary

Change `id` from `int` (bare PR number) to `string` (commit key). The ID is always the source-repo commit key — uniform format, no conditional logic.

## Before

```json
{
  "id": 112345,
  "repo": "runtime",
  ...
}
```

`id: 112345` is only unique within `runtime`. Two repos can both have PR #100.

## After

```json
{
  "id": "runtime@c5d5be4",
  "repo": "runtime",
  ...
}
```

Unique by construction, self-describing, consistent with `commits{}` key format.

## Changes

- `ChangeEntry.Id`: `int` → `string`
- Normal changes: `Id = commitKey` (e.g. `runtime@c5d5be4`)
- Security direct patches: `Id = dotnetCommitKey` (e.g. `dotnet@a1b2c3d`)
- Bump: 2.0.0 → 2.1.0

Closes #40