### PR TITLE
Add skill command and fix nuget JSON key

### DIFF
--- a/src/Dotnet.Release.Changes/BuildMetadata.cs
+++ b/src/Dotnet.Release.Changes/BuildMetadata.cs
@@ -17,6 +17,7 @@ public record BuildMetadata(
     [property: Description("Build version information.")]
     BuildInfo Build,
 
+    [property: JsonPropertyName("nuget")]
     [property: Description("NuGet feed and package information for API verification.")]
     NuGetInfo NuGet
 );

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -41,6 +41,7 @@
     <EmbeddedResource Include="dotnet-dependencies-template.md" />
     <EmbeddedResource Include="dotnet-packages-template.md" />
     <EmbeddedResource Include="releases-template.md" />
+    <EmbeddedResource Include="SKILL.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -16,6 +16,11 @@ using Dotnet.Release.Tools;
 //        dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]
 // Types: supported-os, os-packages, changes
 
+if (args.Length >= 1 && args[0] == "skill")
+{
+    return PrintSkill();
+}
+
 if (args.Length < 2)
 {
     PrintUsage();
@@ -655,12 +660,28 @@ async Task<int> HandleGenerateChangesAsync(string[] args)
     return 0;
 }
 
+static int PrintSkill()
+{
+    using var stream = typeof(Program).Assembly.GetManifestResourceStream("Dotnet.Release.Tools.SKILL.md");
+
+    if (stream is null)
+    {
+        Console.Error.WriteLine("Error: SKILL.md resource not found.");
+        return 1;
+    }
+
+    using var reader = new StreamReader(stream);
+    Console.WriteLine(reader.ReadToEnd());
+    return 0;
+}
+
 static void PrintUsage()
 {
     Console.Error.WriteLine("Usage: dotnet-release generate <type> <version> [path-or-url] [--template <file>]");
     Console.Error.WriteLine("       dotnet-release generate releases-index [path]");
     Console.Error.WriteLine("       dotnet-release generate releases [path] [--template <file>]");
     Console.Error.WriteLine("       dotnet-release generate changes <repo-path> --base <ref> --head <ref> [options]");
+    Console.Error.WriteLine("       dotnet-release generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]");
     Console.Error.WriteLine("       dotnet-release generate version-index <input-dir> [output-dir] [--url-root <url>]");
     Console.Error.WriteLine("       dotnet-release generate timeline-index <input-dir> [output-dir] [--url-root <url>]");
     Console.Error.WriteLine("       dotnet-release generate llms-index <input-dir> [output-dir] [--url-root <url>]");
@@ -669,9 +690,10 @@ static void PrintUsage()
     Console.Error.WriteLine("       dotnet-release verify <type> <version> [path-or-url]");
     Console.Error.WriteLine("       dotnet-release verify releases [version] [path] [--skip-hash]");
     Console.Error.WriteLine("       dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]");
+    Console.Error.WriteLine("       dotnet-release skill");
     Console.Error.WriteLine();
-    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, changes, releases-index,");
-    Console.Error.WriteLine("       releases, version-index, timeline-index, llms-index, indexes");
+    Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, changes, build-metadata,");
+    Console.Error.WriteLine("       releases-index, releases, version-index, timeline-index, llms-index, indexes");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Changes options:");
     Console.Error.WriteLine("  --base <ref>       Base git ref (tag, branch, or commit)");

--- a/src/Dotnet.Release.Tools/SKILL.md
+++ b/src/Dotnet.Release.Tools/SKILL.md
@@ -1,0 +1,165 @@
+# dotnet-release
+
+CLI tool for generating release metadata from .NET release data and the VMR (dotnet/dotnet).
+
+## Quick Decision Tree
+
+- **Writing release notes?** → `generate changes` to get the change log between two refs
+- **Verifying APIs against nightly builds?** → `generate build-metadata` for feed URLs and package versions
+- **Updating support matrices?** → `generate supported-os` / `generate os-packages`
+- **Regenerating release pages?** → `generate releases` / `generate releases-index`
+- **Building index files?** → `generate indexes` for version/timeline/llms indexes
+
+## When to Use This Tool
+
+- Generating change logs between .NET preview or release tags
+- Discovering nightly build versions and NuGet feed URLs for API verification
+- Producing markdown for supported-os, os-packages, dotnet-dependencies, releases
+- Cross-referencing CVE security data with code changes
+- Building release index and timeline files
+
+## Key Commands
+
+### generate changes
+
+Produces a structured JSON change log between two VMR refs, with per-repo commit/PR attribution, VMR commit mapping, and optional CVE cross-referencing.
+
+```bash
+dotnet-release generate changes <repo-path> --base <ref> --head <ref> [options]
+```
+
+Options:
+- `--base <ref>` — Base git ref (tag, branch, or commit)
+- `--head <ref>` — Head git ref (tag, branch, or commit)
+- `--branch <name>` — Branch name for commit metadata
+- `--version <ver>` — Release version string for the output
+- `--date <date>` — Release date (ISO 8601) for the output
+- `--cve-repo <path>` — Path to dotnet/core clone (cross-references CVE data)
+- `--labels` — Fetch PR labels from GitHub (requires GITHUB_TOKEN)
+- `--jsonl` — Output JSONL (one repo per line) instead of single JSON
+- `--output <file>` — Write output to file instead of stdout
+
+Examples:
+```bash
+# Changes between two preview tags
+dotnet-release generate changes ~/git/dotnet \
+  --base v11.0.0-preview.2.26159.112 \
+  --head v11.0.0-preview.3.26179.102
+
+# Changes on main with CVE cross-referencing
+dotnet-release generate changes ~/git/dotnet \
+  --base v11.0.0-preview.2.26159.112 --head main \
+  --branch main --cve-repo ~/git/core --output changes.json
+```
+
+### generate build-metadata
+
+Produces build metadata for API verification against nightly NuGet packages. Reads VMR version info and queries the nightly NuGet feed for latest package versions.
+
+```bash
+dotnet-release generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]
+```
+
+Output includes:
+- Release version and preview branding
+- Latest nightly build version matching the target preview
+- SDK version and ci.dot.net tarball URL (with `{platform}` placeholder)
+- NuGet feed URL and ref pack/standalone package versions
+
+Example output:
+```json
+{
+  "version": "11.0.0-preview.3",
+  "base_ref": "v11.0.0-preview.2.26159.112",
+  "head_ref": "release/11.0.1xx-preview3",
+  "build": {
+    "version": "11.0.0-preview.3.26179.102",
+    "sdk_version": "11.0.100-preview.3.26179.102",
+    "sdk_url": "https://ci.dot.net/public/Sdk/11.0.100-preview.3.26179.102/dotnet-sdk-11.0.100-preview.3.26179.102-{platform}.tar.gz"
+  },
+  "nuget": {
+    "source": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json",
+    "packages": {
+      "Microsoft.NETCore.App.Ref": "11.0.0-preview.3.26179.102",
+      "Microsoft.AspNetCore.App.Ref": "11.0.0-preview.3.26179.102",
+      "Microsoft.WindowsDesktop.App.Ref": "11.0.0-preview.3.26179.102",
+      "Microsoft.EntityFrameworkCore": "11.0.0-preview.3.26118.109",
+      "Microsoft.Data.Sqlite.Core": "11.0.0-preview.3.26118.109"
+    }
+  }
+}
+```
+
+Using build metadata with dotnet-inspect for API verification:
+```bash
+# Read values from build-metadata.json
+VER="11.0.0-preview.3.26179.102"
+FEED="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json"
+
+# Verify a runtime API exists in this preview
+dnx dotnet-inspect -y -- find "*AnyNewLine*" \
+  --package "Microsoft.NETCore.App.Ref@${VER}" --source "$FEED"
+
+# Verify an ASP.NET Core API
+dnx dotnet-inspect -y -- find "*Zstandard*" \
+  --package "Microsoft.AspNetCore.App.Ref@${VER}" --source "$FEED"
+```
+
+### generate supported-os / os-packages / dotnet-dependencies / dotnet-packages
+
+Generates markdown from .NET release JSON data for support matrices and dependency tables.
+
+```bash
+dotnet-release generate <type> <version> [path-or-url] [--template <file>]
+dotnet-release generate <type> --export-template
+```
+
+### generate releases / releases-index
+
+Generates release pages and index files from the dotnet/core release-notes tree.
+
+```bash
+dotnet-release generate releases [path] [--template <file>]
+dotnet-release generate releases-index [path]
+```
+
+### generate indexes
+
+Generates version, timeline, and LLMs index files.
+
+```bash
+dotnet-release generate indexes <input-dir> [output-dir] [--url-root <url>]
+dotnet-release generate version-index <input-dir> [output-dir] [--url-root <url>]
+dotnet-release generate timeline-index <input-dir> [output-dir] [--url-root <url>]
+dotnet-release generate llms-index <input-dir> [output-dir] [--url-root <url>]
+```
+
+### verify
+
+Validates generated release data against source JSON.
+
+```bash
+dotnet-release verify <type> <version> [path-or-url]
+dotnet-release verify releases [version] [path] [--skip-hash]
+```
+
+### query distro-packages
+
+Queries distro package availability for a given .NET version.
+
+```bash
+dotnet-release query distro-packages --dotnet-version <ver> [--output <file>]
+```
+
+Requires PKGS_ORG_TOKEN environment variable.
+
+## Environment Variables
+
+- `GITHUB_TOKEN` — Required for `generate changes --labels` (GitHub API access)
+- `PKGS_ORG_TOKEN` — Required for `query distro-packages` (pkgs.org API access)
+
+## Installation
+
+```bash
+dotnet tool install -g Dotnet.Release.Tools --prerelease
+```

--- a/src/Dotnet.Release.Tools/SKILL.md
+++ b/src/Dotnet.Release.Tools/SKILL.md
@@ -40,6 +40,7 @@ Options:
 - `--output <file>` — Write output to file instead of stdout
 
 Examples:
+
 ```bash
 # Changes between two preview tags
 dotnet-release generate changes ~/git/dotnet \
@@ -67,6 +68,7 @@ Output includes:
 - NuGet feed URL and ref pack/standalone package versions
 
 Example output:
+
 ```json
 {
   "version": "11.0.0-preview.3",
@@ -91,6 +93,7 @@ Example output:
 ```
 
 Using build metadata with dotnet-inspect for API verification:
+
 ```bash
 # Read values from build-metadata.json
 VER="11.0.0-preview.3.26179.102"


### PR DESCRIPTION
Two changes:

### 1. Add `dotnet-release skill` subcommand

Prints an embedded `SKILL.md` for LLM consumption — comprehensive command reference covering all `generate`, `verify`, and `query` subcommands with examples. Follows the same pattern as `dotnet-inspect skill`.

Also adds `build-metadata` to `PrintUsage` output.

### 2. Fix `nu_get` → `nuget` JSON key

The `SnakeCaseLower` naming policy splits `NuGet` into `nu_get`. Fixed with an explicit `[JsonPropertyName("nuget")]` attribute.

Closes #44