### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-release</ToolCommandName>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <PackageId>Dotnet.Release.Tools</PackageId>
     <Description>CLI tools for generating markdown from .NET release data</Description>
     <!-- Size optimizations for Native AOT -->


### PR DESCRIPTION
Version bump 2.2.0 → 2.3.0 to publish updated tool with:

- `dotnet-release skill` command (embedded SKILL.md)
- `nuget` JSON key fix (was `nu_get`)
- `build-metadata` added to PrintUsage
- Standalone annual packages (EF Core, SQLite) in build metadata