### PR TITLE
Rename maintainer tool to release-notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,8 @@ jobs:
         run: |
           dotnet tool install -g Dotnet.Release.Tool --add-source artifacts/package/release --prerelease
           dotnet-release --help || true
-          dotnet tool install -g ReleaseNotes.Gen --add-source artifacts/package/release --prerelease
-          release-notes-gen --help || true
+          dotnet tool install -g release-notes --add-source artifacts/package/release --prerelease
+          release-notes --help || true
           dotnet tool install -g Dotnet.Release.CveEnricher --add-source artifacts/package/release --prerelease
           dotnet-cve-enricher || true
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install tools globally:
 
 ```bash
 dotnet tool install -g Dotnet.Release.Tool
-dotnet tool install -g ReleaseNotes.Gen
+dotnet tool install -g release-notes
 ```
 
 ### `dotnet-release`
@@ -69,14 +69,14 @@ dotnet-release cves --product runtime -n 12
 dotnet-release cves --package System.Security.Cryptography.Cose since 2026-01
 ```
 
-### `release-notes-gen`
+### `release-notes`
 
 Maintainer CLI for generating markdown and index files from .NET release data.
 
 | Subcommand | Description |
 |---|---|
-| `release-notes-gen generate supported-os <version>` | Generates supported-os.md from supported-os.json |
-| `release-notes-gen generate os-packages <version>` | Generates os-packages.md from os-packages.json |
+| `release-notes generate supported-os <version>` | Generates supported-os.md from supported-os.json |
+| `release-notes generate os-packages <version>` | Generates os-packages.md from os-packages.json |
 
 Options:
 
@@ -87,7 +87,7 @@ Options:
 Examples:
 
 ```bash
-release-notes-gen generate supported-os 10.0
-release-notes-gen generate os-packages 10.0 ~/git/core/release-notes
-release-notes-gen generate supported-os --export-template > my-template.md
+release-notes generate supported-os 10.0
+release-notes generate os-packages 10.0 ~/git/core/release-notes
+release-notes generate supported-os --export-template > my-template.md
 ```

--- a/skills/dotnet-releases/SKILL.md
+++ b/skills/dotnet-releases/SKILL.md
@@ -81,4 +81,4 @@ Start broad, then drill down:
 - Summarize the result in natural language with exact dates and versions.
 - Avoid dumping raw command output unless the user asks for it.
 - If a question needs package or product scoping, add `--package` or `--product` instead of manually filtering.
-- Use `release-notes-gen` only for maintainer workflows; it is not the public query surface.
+- Use `release-notes` only for maintainer workflows; it is not the public query surface.

--- a/skills/update-distro-packages/SKILL.md
+++ b/skills/update-distro-packages/SKILL.md
@@ -28,10 +28,10 @@ release-notes/11.0/distros/
 
 ## Prerequisites
 
-The `release-notes-gen` tool must be installed globally. It provides the pkgs.org query client:
+The `release-notes` tool must be installed globally. It provides the pkgs.org query client:
 
 ```bash
-release-notes-gen query distro-packages --dotnet-version 11.0
+release-notes query distro-packages --dotnet-version 11.0
 ```
 
 Requires `PKGS_ORG_TOKEN` environment variable (pkgs.org Gold+ subscription).
@@ -70,7 +70,7 @@ When a new distro release ships (e.g. Ubuntu 28.04):
 
 ### 3. Updating .NET package availability
 
-1. Run `release-notes-gen query distro-packages --dotnet-version <ver>` to get current package data from pkgs.org
+1. Run `release-notes query distro-packages --dotnet-version <ver>` to get current package data from pkgs.org
 2. For each distro file, update `dotnet_packages` (built-in feed) and `dotnet_packages_other` (alternative feeds)
 3. Update the root `dotnet_versions` array to reflect all available versions
 4. Dictionary keys: versions descending, feed names ascending, component names ascending

--- a/skills/update-os-packages/SKILL.md
+++ b/skills/update-os-packages/SKILL.md
@@ -15,7 +15,7 @@ Audit and update `os-packages.json` files in the [dotnet/core](https://github.co
 
 ## Prerequisites
 
-The `release-notes-gen` tool is installed globally. Run `release-notes-gen --help` to confirm.
+The `release-notes` tool is installed globally. Run `release-notes --help` to confirm.
 
 ## Inputs
 
@@ -33,7 +33,7 @@ For each version, read `release-notes/{version}/os-packages.json`.
 
 ### 2. Verify package names
 
-Run the `release-notes-gen verify os-packages` command for each version. The tool checks each package name against upstream distro package feeds and reports mismatches.
+Run the `release-notes verify os-packages` command for each version. The tool checks each package name against upstream distro package feeds and reports mismatches.
 
 ### 3. Cross-reference with supported-os.json
 

--- a/skills/update-supported-os/SKILL.md
+++ b/skills/update-supported-os/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-supported-os
-description: Audit and update supported-os.json files in dotnet/core to reflect current OS version support. Uses release-notes-gen verify for automated checking against upstream lifecycle data.
+description: Audit and update supported-os.json files in dotnet/core to reflect current OS version support. Uses release-notes verify for automated checking against upstream lifecycle data.
 ---
 
 # Update Supported OS
@@ -15,7 +15,7 @@ Audit and update `supported-os.json` files in the [dotnet/core](https://github.c
 
 ## Prerequisites
 
-The `release-notes-gen` tool is installed globally. Run `release-notes-gen --help` to confirm.
+The `release-notes` tool is installed globally. Run `release-notes --help` to confirm.
 
 ## Inputs
 
@@ -31,16 +31,16 @@ The user provides:
 Run the verify command for each .NET version to audit:
 
 ```bash
-release-notes-gen verify supported-os <version> [path-or-url]
+release-notes verify supported-os <version> [path-or-url]
 ```
 
 Examples:
 ```bash
 # Check against live data on GitHub (default)
-release-notes-gen verify supported-os 10.0
+release-notes verify supported-os 10.0
 
 # Check against a local clone
-release-notes-gen verify supported-os 10.0 ~/git/core/release-notes
+release-notes verify supported-os 10.0 ~/git/core/release-notes
 ```
 
 **Interpret the exit code:**
@@ -86,7 +86,7 @@ For each confirmed change, edit `release-notes/<version>/supported-os.json`:
 After updating the JSON, regenerate the markdown file:
 
 ```bash
-release-notes-gen generate supported-os <version> <core-path>/release-notes
+release-notes generate supported-os <version> <core-path>/release-notes
 ```
 
 This overwrites `supported-os.md` with content derived from the updated JSON.
@@ -111,7 +111,7 @@ Check if any newly added distro versions need entries in `os-packages.json`. If 
 
 1. Run verify again to confirm issues are resolved:
    ```bash
-   release-notes-gen verify supported-os <version> <core-path>/release-notes
+   release-notes verify supported-os <version> <core-path>/release-notes
    ```
    Expect exit code 0 (or only TIP/CAUTION items remaining).
 

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>release-notes-gen</ToolCommandName>
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <PackageId>ReleaseNotes.Gen</PackageId>
+    <ToolCommandName>release-notes</ToolCommandName>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageId>release-notes</PackageId>
     <Description>Maintainer CLI for generating and verifying .NET release notes data</Description>
     <!-- Size optimizations for Native AOT -->
     <UseSystemResourceKeys>true</UseSystemResourceKeys>

--- a/src/Dotnet.Release.Tools/Program.cs
+++ b/src/Dotnet.Release.Tools/Program.cs
@@ -8,12 +8,12 @@ using Dotnet.Release.Summary;
 using Dotnet.Release.Support;
 using Dotnet.Release.Tools;
 
-// Usage: release-notes-gen generate <type> <version> [path-or-url] [--template <file>]
-//        release-notes-gen generate <type> --export-template
-//        release-notes-gen generate changes <repo-path> --base <ref> --head <ref> [--branch <branch>] [--version <ver>] [--date <date>] [--output <file>]
-//        release-notes-gen generate version-index|timeline-index|llms-index|indexes <input-dir> [output-dir] [--url-root <url>]
-//        release-notes-gen verify <type> <version> [path-or-url]
-//        release-notes-gen query distro-packages --dotnet-version <ver> [--output <file>]
+// Usage: release-notes generate <type> <version> [path-or-url] [--template <file>]
+//        release-notes generate <type> --export-template
+//        release-notes generate changes <repo-path> --base <ref> --head <ref> [--branch <branch>] [--version <ver>] [--date <date>] [--output <file>]
+//        release-notes generate version-index|timeline-index|llms-index|indexes <input-dir> [output-dir] [--url-root <url>]
+//        release-notes verify <type> <version> [path-or-url]
+//        release-notes query distro-packages --dotnet-version <ver> [--output <file>]
 // Types: supported-os, os-packages, changes
 
 if (args.Length >= 1 && args[0] == "skill")
@@ -75,13 +75,13 @@ if (args.Length > 2 && args[2] == "--export-template")
     return 0;
 }
 
-// Changes generator: release-notes-gen generate changes <repo-path> --base <ref> --head <ref> ...
+// Changes generator: release-notes generate changes <repo-path> --base <ref> --head <ref> ...
 if (type == "changes")
 {
     return await HandleGenerateChangesAsync(args);
 }
 
-// Build metadata generator: release-notes-gen generate build-metadata <repo-path> --base <ref> --head <ref> [--output file]
+// Build metadata generator: release-notes generate build-metadata <repo-path> --base <ref> --head <ref> [--output file]
 if (type == "build-metadata")
 {
     return await HandleGenerateBuildMetadataAsync(args);
@@ -524,7 +524,7 @@ async Task<int> VerifyReleasesAsync(string basePath, string? version, bool skipH
     Console.Error.WriteLine($"Verifying release links for {scope} in {Path.GetFullPath(basePath)}...");
 
     using var client = new HttpClient();
-    client.DefaultRequestHeaders.UserAgent.ParseAdd("release-notes-gen-verifier/1.0");
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("release-notes-verifier/1.0");
     client.Timeout = TimeSpan.FromMinutes(5);
 
     var report = await ReleasesVerifier.VerifyAsync(basePath, client, Console.Error, skipHash, version);
@@ -613,7 +613,7 @@ async Task<int> HandleGenerateChangesAsync(string[] args)
 
     using var httpClient = new HttpClient();
     httpClient.DefaultRequestHeaders.Add("Authorization", $"token {token}");
-    httpClient.DefaultRequestHeaders.Add("User-Agent", "release-notes-gen-tool");
+    httpClient.DefaultRequestHeaders.Add("User-Agent", "release-notes-tool");
 
     var generator = new ChangesGenerator(httpClient);
     var records = await generator.GenerateAsync(
@@ -677,21 +677,21 @@ static int PrintSkill()
 
 static void PrintUsage()
 {
-    Console.Error.WriteLine("Usage: release-notes-gen generate <type> <version> [path-or-url] [--template <file>]");
-    Console.Error.WriteLine("       release-notes-gen generate releases-index [path]");
-    Console.Error.WriteLine("       release-notes-gen generate releases [path] [--template <file>]");
-    Console.Error.WriteLine("       release-notes-gen generate changes <repo-path> --base <ref> --head <ref> [options]");
-    Console.Error.WriteLine("       release-notes-gen generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]");
-    Console.Error.WriteLine("       release-notes-gen generate version-index <input-dir> [output-dir] [--url-root <url>]");
-    Console.Error.WriteLine("       release-notes-gen generate timeline-index <input-dir> [output-dir] [--url-root <url>]");
-    Console.Error.WriteLine("       release-notes-gen generate llms-index <input-dir> [output-dir] [--url-root <url>]");
-    Console.Error.WriteLine("       release-notes-gen generate indexes <input-dir> [output-dir] [--url-root <url>]");
-    Console.Error.WriteLine("       release-notes-gen generate <type> --export-template");
-    Console.Error.WriteLine("       release-notes-gen verify <type> <version> [path-or-url]");
-    Console.Error.WriteLine("       release-notes-gen verify releases [version] [path] [--skip-hash]");
-    Console.Error.WriteLine("       release-notes-gen query changes-previews [repo-path]");
-    Console.Error.WriteLine("       release-notes-gen query distro-packages --dotnet-version <ver> [--output <file>]");
-    Console.Error.WriteLine("       release-notes-gen skill");
+    Console.Error.WriteLine("Usage: release-notes generate <type> <version> [path-or-url] [--template <file>]");
+    Console.Error.WriteLine("       release-notes generate releases-index [path]");
+    Console.Error.WriteLine("       release-notes generate releases [path] [--template <file>]");
+    Console.Error.WriteLine("       release-notes generate changes <repo-path> --base <ref> --head <ref> [options]");
+    Console.Error.WriteLine("       release-notes generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]");
+    Console.Error.WriteLine("       release-notes generate version-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       release-notes generate timeline-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       release-notes generate llms-index <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       release-notes generate indexes <input-dir> [output-dir] [--url-root <url>]");
+    Console.Error.WriteLine("       release-notes generate <type> --export-template");
+    Console.Error.WriteLine("       release-notes verify <type> <version> [path-or-url]");
+    Console.Error.WriteLine("       release-notes verify releases [version] [path] [--skip-hash]");
+    Console.Error.WriteLine("       release-notes query changes-previews [repo-path]");
+    Console.Error.WriteLine("       release-notes query distro-packages --dotnet-version <ver> [--output <file>]");
+    Console.Error.WriteLine("       release-notes skill");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Types: supported-os, os-packages, dotnet-dependencies, changes, build-metadata,");
     Console.Error.WriteLine("       releases-index, releases, version-index, timeline-index, llms-index, indexes");
@@ -708,32 +708,32 @@ static void PrintUsage()
     Console.Error.WriteLine("  --output <file>    Write output to file instead of stdout");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
-    Console.Error.WriteLine("  release-notes-gen generate supported-os 10.0");
-    Console.Error.WriteLine("  release-notes-gen generate os-packages 10.0");
-    Console.Error.WriteLine("  release-notes-gen generate dotnet-dependencies 11.0");
-    Console.Error.WriteLine("  release-notes-gen generate dotnet-dependencies 11.0 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate supported-os 10.0 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate os-packages --export-template > my-template.md");
-    Console.Error.WriteLine("  release-notes-gen generate releases-index ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate releases ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate releases --export-template > my-template.md");
-    Console.Error.WriteLine("  release-notes-gen generate changes ~/git/dotnet --base v11.0.0-preview.1.25060.1 --head v11.0.0-preview.2.26159.112");
-    Console.Error.WriteLine("  release-notes-gen generate changes ~/git/dotnet --base v11.0.0-preview.2.26159.112 --head main --branch main --output changes.json");
-    Console.Error.WriteLine("  release-notes-gen generate version-index ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate timeline-index ~/git/core/release-notes /tmp/output");
-    Console.Error.WriteLine("  release-notes-gen generate llms-index ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen generate indexes ~/git/core/release-notes --url-root https://raw.githubusercontent.com/dotnet/core/abc123");
-    Console.Error.WriteLine("  release-notes-gen verify supported-os 10.0");
-    Console.Error.WriteLine("  release-notes-gen verify supported-os 10.0 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen verify os-packages 10.0");
-    Console.Error.WriteLine("  release-notes-gen verify os-packages 10.0 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen verify releases ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen verify releases 10.0 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen verify releases 10.0.5 ~/git/core/release-notes");
-    Console.Error.WriteLine("  release-notes-gen verify releases ~/git/core/release-notes --skip-hash");
-    Console.Error.WriteLine("  release-notes-gen query changes-previews ~/git/dotnet");
-    Console.Error.WriteLine("  release-notes-gen query distro-packages --dotnet-version 9.0");
-    Console.Error.WriteLine("  release-notes-gen query distro-packages --dotnet-version 9.0 --output distro-packages.json");
+    Console.Error.WriteLine("  release-notes generate supported-os 10.0");
+    Console.Error.WriteLine("  release-notes generate os-packages 10.0");
+    Console.Error.WriteLine("  release-notes generate dotnet-dependencies 11.0");
+    Console.Error.WriteLine("  release-notes generate dotnet-dependencies 11.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate supported-os 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate os-packages --export-template > my-template.md");
+    Console.Error.WriteLine("  release-notes generate releases-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate releases ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate releases --export-template > my-template.md");
+    Console.Error.WriteLine("  release-notes generate changes ~/git/dotnet --base v11.0.0-preview.1.25060.1 --head v11.0.0-preview.2.26159.112");
+    Console.Error.WriteLine("  release-notes generate changes ~/git/dotnet --base v11.0.0-preview.2.26159.112 --head main --branch main --output changes.json");
+    Console.Error.WriteLine("  release-notes generate version-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate timeline-index ~/git/core/release-notes /tmp/output");
+    Console.Error.WriteLine("  release-notes generate llms-index ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes generate indexes ~/git/core/release-notes --url-root https://raw.githubusercontent.com/dotnet/core/abc123");
+    Console.Error.WriteLine("  release-notes verify supported-os 10.0");
+    Console.Error.WriteLine("  release-notes verify supported-os 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes verify os-packages 10.0");
+    Console.Error.WriteLine("  release-notes verify os-packages 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes verify releases ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes verify releases 10.0 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes verify releases 10.0.5 ~/git/core/release-notes");
+    Console.Error.WriteLine("  release-notes verify releases ~/git/core/release-notes --skip-hash");
+    Console.Error.WriteLine("  release-notes query changes-previews ~/git/dotnet");
+    Console.Error.WriteLine("  release-notes query distro-packages --dotnet-version 9.0");
+    Console.Error.WriteLine("  release-notes query distro-packages --dotnet-version 9.0 --output distro-packages.json");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Environment variables:");
     Console.Error.WriteLine("  GITHUB_TOKEN    GitHub API token (required for generate changes)");
@@ -968,7 +968,7 @@ async Task<int> HandleGenerateBuildMetadataAsync(string[] args)
 
     if (repoPath is null || baseRef is null || headRef is null)
     {
-        Console.Error.WriteLine("Usage: release-notes-gen generate build-metadata <repo-path> --base <ref> --head <ref> [--output file]");
+        Console.Error.WriteLine("Usage: release-notes generate build-metadata <repo-path> --base <ref> --head <ref> [--output file]");
         return 1;
     }
 

--- a/src/Dotnet.Release.Tools/SKILL.md
+++ b/src/Dotnet.Release.Tools/SKILL.md
@@ -1,4 +1,4 @@
-# release-notes-gen
+# release-notes
 
 CLI tool for generating release metadata from .NET release data and the VMR (dotnet/dotnet).
 
@@ -26,7 +26,7 @@ CLI tool for generating release metadata from .NET release data and the VMR (dot
 Produces a structured JSON change log between two VMR refs, with per-repo commit/PR attribution, VMR commit mapping, and optional CVE cross-referencing.
 
 ```bash
-release-notes-gen generate changes <repo-path> --base <ref> --head <ref> [options]
+release-notes generate changes <repo-path> --base <ref> --head <ref> [options]
 ```
 
 Options:
@@ -44,12 +44,12 @@ Examples:
 
 ```bash
 # Changes between two preview tags
-release-notes-gen generate changes ~/git/dotnet \
+release-notes generate changes ~/git/dotnet \
   --base v11.0.0-preview.2.26159.112 \
   --head v11.0.0-preview.3.26179.102
 
 # Changes on main with CVE cross-referencing
-release-notes-gen generate changes ~/git/dotnet \
+release-notes generate changes ~/git/dotnet \
   --base v11.0.0-preview.2.26159.112 --head main \
   --branch main --cve-repo ~/git/core --output changes.json
 ```
@@ -59,7 +59,7 @@ release-notes-gen generate changes ~/git/dotnet \
 Lists the preview release versions currently visible in a dotnet/dotnet clone, one per line, along with the head ref an agent can feed into `generate changes`.
 
 ```bash
-release-notes-gen query changes-previews ~/git/dotnet
+release-notes query changes-previews ~/git/dotnet
 
 # Example output
 11.0.0-preview.3  head=origin/release/11.0.1xx-preview3
@@ -71,7 +71,7 @@ release-notes-gen query changes-previews ~/git/dotnet
 Produces build metadata for API verification against nightly NuGet packages. Reads VMR version info and queries the nightly NuGet feed for latest package versions.
 
 ```bash
-release-notes-gen generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]
+release-notes generate build-metadata <repo-path> --base <ref> --head <ref> [--output <file>]
 ```
 
 Output includes:
@@ -126,8 +126,8 @@ dnx dotnet-inspect -y -- find "*Zstandard*" \
 Generates markdown from .NET release JSON data for support matrices and dependency tables.
 
 ```bash
-release-notes-gen generate <type> <version> [path-or-url] [--template <file>]
-release-notes-gen generate <type> --export-template
+release-notes generate <type> <version> [path-or-url] [--template <file>]
+release-notes generate <type> --export-template
 ```
 
 ### generate releases / releases-index
@@ -135,8 +135,8 @@ release-notes-gen generate <type> --export-template
 Generates release pages and index files from the dotnet/core release-notes tree.
 
 ```bash
-release-notes-gen generate releases [path] [--template <file>]
-release-notes-gen generate releases-index [path]
+release-notes generate releases [path] [--template <file>]
+release-notes generate releases-index [path]
 ```
 
 ### generate indexes
@@ -144,10 +144,10 @@ release-notes-gen generate releases-index [path]
 Generates version, timeline, and LLMs index files.
 
 ```bash
-release-notes-gen generate indexes <input-dir> [output-dir] [--url-root <url>]
-release-notes-gen generate version-index <input-dir> [output-dir] [--url-root <url>]
-release-notes-gen generate timeline-index <input-dir> [output-dir] [--url-root <url>]
-release-notes-gen generate llms-index <input-dir> [output-dir] [--url-root <url>]
+release-notes generate indexes <input-dir> [output-dir] [--url-root <url>]
+release-notes generate version-index <input-dir> [output-dir] [--url-root <url>]
+release-notes generate timeline-index <input-dir> [output-dir] [--url-root <url>]
+release-notes generate llms-index <input-dir> [output-dir] [--url-root <url>]
 ```
 
 ### verify
@@ -155,8 +155,8 @@ release-notes-gen generate llms-index <input-dir> [output-dir] [--url-root <url>
 Validates generated release data against source JSON.
 
 ```bash
-release-notes-gen verify <type> <version> [path-or-url]
-release-notes-gen verify releases [version] [path] [--skip-hash]
+release-notes verify <type> <version> [path-or-url]
+release-notes verify releases [version] [path] [--skip-hash]
 ```
 
 ### query distro-packages
@@ -164,7 +164,7 @@ release-notes-gen verify releases [version] [path] [--skip-hash]
 Queries distro package availability for a given .NET version.
 
 ```bash
-release-notes-gen query distro-packages --dotnet-version <ver> [--output <file>]
+release-notes query distro-packages --dotnet-version <ver> [--output <file>]
 ```
 
 Requires PKGS_ORG_TOKEN environment variable.
@@ -177,5 +177,5 @@ Requires PKGS_ORG_TOKEN environment variable.
 ## Installation
 
 ```bash
-dotnet tool install -g ReleaseNotes.Gen --prerelease
+dotnet tool install -g release-notes --prerelease
 ```

--- a/test/agent-tests.md
+++ b/test/agent-tests.md
@@ -5,7 +5,7 @@ Validation scenarios for agent-driven skills. Each test defines a workflow an AI
 ## Test 1: Update Supported OS
 
 **Skill:** `update-supported-os`
-**Tool:** `release-notes-gen verify supported-os`
+**Tool:** `release-notes verify supported-os`
 
 An agent audits the .NET supported OS matrix against upstream lifecycle data and, if issues are found, prepares a PR with fixes.
 
@@ -17,7 +17,7 @@ verify → early-out if clean → update JSON → regenerate markdown → PR
 
 ### Supported OS steps
 
-1. **Verify** — Run `release-notes-gen verify supported-os <version>` for each active .NET version. The report categorizes issues as:
+1. **Verify** — Run `release-notes verify supported-os <version>` for each active .NET version. The report categorizes issues as:
    - ⚠️ WARNING: EOL but still listed as supported — move to `unsupported-versions`
    - ❗ IMPORTANT: Active releases not listed — consider adding to `supported-versions`
    - 💡 TIP: Active but listed as unsupported — verify intentional
@@ -27,7 +27,7 @@ verify → early-out if clean → update JSON → regenerate markdown → PR
    - Move EOL versions from `supported-versions` to `unsupported-versions`
    - Add missing active versions to `supported-versions` (sorted newest-first)
    - Update `last-updated` to today's date
-4. **Regenerate** — Run `release-notes-gen generate supported-os <version> <core-path>/release-notes` to regenerate the markdown.
+4. **Regenerate** — Run `release-notes generate supported-os <version> <core-path>/release-notes` to regenerate the markdown.
 5. **PR** — Create a branch, commit changes, and open a PR against `dotnet/core`.
 
 ### Supported OS success criteria


### PR DESCRIPTION
## Summary
- rename the private maintainer CLI package and command to `release-notes`
- reset the renamed tool version to `1.0.0` now that it ships under a new identity
- update docs, skills, and CI smoke tests to use the new install and invocation name

## Validation
- `dotnet build DotnetRelease.slnx`
- `dotnet test DotnetRelease.slnx`
- packed and installed `release-notes` version `1.0.0` locally and ran `release-notes --help`