### PR TITLE
Fix SDK band verification and bump release-notes to 1.0.1

### DIFF
--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>release-notes</ToolCommandName>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageId>release-notes</PackageId>
     <Description>Maintainer CLI for generating and verifying .NET release notes data</Description>
     <!-- Size optimizations for Native AOT -->

--- a/src/Dotnet.Release.Tools/ReleasesVerifier.cs
+++ b/src/Dotnet.Release.Tools/ReleasesVerifier.cs
@@ -185,7 +185,7 @@ public static class ReleasesVerifier
         var versionMismatches = await VerifyLatestVersionFilesAsync(version, overview, client, log);
 
         // Verify aka.ms redirect targets match releases.json URLs
-        var akamsLinks = CollectAkamsLinks(release, version, releasesNotesPath, log);
+        var akamsLinks = CollectAkamsLinks(release, overview, version, releasesNotesPath, log);
         var akamsMismatches = await VerifyAkamsLinksAsync(akamsLinks, log);
 
         // Build report
@@ -380,7 +380,7 @@ public static class ReleasesVerifier
     /// Each link is paired with the expected concrete download URL from releases.json.
     /// </summary>
     static List<AkamsInfo> CollectAkamsLinks(
-        PatchRelease release, string version, string releasesNotesPath, TextWriter log)
+        PatchRelease release, MajorReleaseOverview overview, string version, string releasesNotesPath, TextWriter log)
     {
         var links = new List<AkamsInfo>();
 
@@ -398,11 +398,12 @@ public static class ReleasesVerifier
         {
             // Build lookup: file name → concrete URL from releases.json
             var urlByName = BuildFileUrlLookup(release);
+            var sdkBandLookups = BuildSdkBandUrlLookups(overview);
 
             foreach (var jsonFile in Directory.GetFiles(downloadsDir, "*.json"))
             {
                 if (Path.GetFileName(jsonFile) == "index.json") continue;
-                AddAkamsFromDownloadsFile(links, jsonFile, urlByName, log);
+                AddAkamsFromDownloadsFile(links, jsonFile, urlByName, sdkBandLookups, log);
             }
         }
 
@@ -442,11 +443,53 @@ public static class ReleasesVerifier
         }
     }
 
+    static Dictionary<string, Dictionary<string, string>> BuildSdkBandUrlLookups(MajorReleaseOverview overview)
+    {
+        var lookups = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var patch in overview.Releases)
+        {
+            if (patch.Sdks is null)
+            {
+                continue;
+            }
+
+            foreach (var sdk in patch.Sdks)
+            {
+                string band = GetSdkFeatureBand(sdk.Version);
+                if (lookups.ContainsKey(band))
+                {
+                    continue;
+                }
+
+                var bandLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                AddFilesToLookup(bandLookup, sdk.Files);
+                lookups.Add(band, bandLookup);
+            }
+        }
+
+        return lookups;
+    }
+
+    static string GetSdkFeatureBand(string sdkVersion)
+    {
+        if (string.IsNullOrEmpty(sdkVersion) || sdkVersion.Length < 5)
+        {
+            return sdkVersion;
+        }
+
+        return $"{sdkVersion[..5]}xx";
+    }
+
     /// <summary>
     /// Reads a downloads/*.json file and collects aka.ms → expected URL pairs.
     /// </summary>
     static void AddAkamsFromDownloadsFile(
-        List<AkamsInfo> links, string jsonFile, Dictionary<string, string> urlByName, TextWriter log)
+        List<AkamsInfo> links,
+        string jsonFile,
+        Dictionary<string, string> urlByName,
+        Dictionary<string, Dictionary<string, string>> sdkBandLookups,
+        TextWriter log)
     {
         try
         {
@@ -455,6 +498,18 @@ public static class ReleasesVerifier
             if (download?.Embedded?.Downloads is null) return;
 
             string component = download.Component ?? Path.GetFileNameWithoutExtension(jsonFile);
+            Dictionary<string, string>? expectedLookup = null;
+
+            if (component.Equals("sdk", StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrEmpty(download.FeatureBand))
+            {
+                if (!sdkBandLookups.TryGetValue(download.FeatureBand, out expectedLookup))
+                {
+                    log.WriteLine($"  ⚠️ Could not find releases.json entries for SDK feature band {download.FeatureBand}.");
+                }
+            }
+
+            expectedLookup ??= urlByName;
 
             foreach (var (_, file) in download.Embedded.Downloads)
             {
@@ -464,7 +519,7 @@ public static class ReleasesVerifier
                     downloadLink.Href.Contains("aka.ms", StringComparison.OrdinalIgnoreCase))
                 {
                     // Match the download file name to the concrete URL in releases.json
-                    if (urlByName.TryGetValue(file.Name, out var expectedUrl))
+                    if (expectedLookup.TryGetValue(file.Name, out var expectedUrl))
                     {
                         links.Add(new AkamsInfo(component, file.Name, downloadLink.Href, expectedUrl));
                     }


### PR DESCRIPTION
## Summary
- fix `release-notes` aka.ms verification for SDK feature-band download links
- bump `release-notes` from `1.0.0` to `1.0.1`
- stop comparing banded SDK aliases like `9.0.2xx` and `8.0.3xx` to the latest overall SDK payload

## Validation
- `dotnet build DotnetRelease.slnx --nologo`
- `dotnet test DotnetRelease.slnx --no-build --nologo`
- `dotnet run --project src/Dotnet.Release.Tools -- verify releases /Users/rich/git/core/release-notes --skip-hash`

## Results
- `.NET 9.0` and `.NET 8.0` are clean in the quick verifier rerun after this fix
- remaining `.NET 10.0` and `.NET 11.0` issues are real CDN/aka.ms drift or unresolved preview aliases
