### PR TITLE
Expose SDK versions in release indexes

### DIFF
--- a/src/Dotnet.Release.Client/PatchSummary.cs
+++ b/src/Dotnet.Release.Client/PatchSummary.cs
@@ -19,5 +19,7 @@ public class PatchSummary
     public SupportPhase? Phase => _entry.SupportPhase;
     public DateTimeOffset? ReleaseDate => _entry.Date;
     public bool IsSecurityUpdate => _entry.Security;
+    public string? SdkVersion => _entry.SdkVersion;
+    public IReadOnlyList<string>? SdkVersions => _entry.SdkVersions;
     public IReadOnlyDictionary<string, HalLink>? Links => _entry.Links;
 }

--- a/src/Dotnet.Release.Graph/PatchReleaseVersionIndex.cs
+++ b/src/Dotnet.Release.Graph/PatchReleaseVersionIndex.cs
@@ -114,6 +114,10 @@ public record PatchReleaseVersionIndexEntry(
      Description("Highest SDK version included in this patch release")]
     public string? SdkVersion { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("All SDK versions included in this patch release")]
+    public IReadOnlyList<string>? SdkVersions { get; init; }
+
     [JsonPropertyName("_links"),
      Description("HAL+JSON links for navigation")]
     public Dictionary<string, HalLink> Links { get; init; } = [];

--- a/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
@@ -347,6 +347,7 @@ public class ReleaseIndexFiles
                             phase)
                         {
                             SdkVersion = e.SdkVersions?.FirstOrDefault(),
+                            SdkVersions = e.SdkVersions,
                             Links = HalHelpers.OrderLinks(links)
                         };
                     }).ToList())

--- a/src/Dotnet.Release.IndexGenerator/ShipIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ShipIndexFiles.cs
@@ -358,6 +358,7 @@ public class ShipIndexFiles
                     {
                         MajorRelease = majorVersion,
                         SdkVersion = sdkVersions?.FirstOrDefault(),
+                        SdkVersions = sdkVersions,
                         Links = HalHelpers.OrderLinks(patchLinks)
                     };
                 }

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -9,7 +9,6 @@
     <Description>Maintainer CLI for generating and verifying .NET release notes data</Description>
     <!-- Size optimizations for Native AOT -->
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
     <!-- RID-specific tool packaging: Native AOT for common platforms, CoreCLR fallback for others -->
     <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>

--- a/test/Dotnet.Release.Graph.Tests/GraphSerializationTests.cs
+++ b/test/Dotnet.Release.Graph.Tests/GraphSerializationTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Dotnet.Release.Graph;
+using Xunit;
+
+namespace Dotnet.Release.Graph.Tests;
+
+public class GraphSerializationTests
+{
+    [Fact]
+    public void PatchReleaseVersionIndexEntry_SerializesSdkVersions()
+    {
+        var entry = new PatchReleaseVersionIndexEntry(
+            "8.0.12",
+            new DateTimeOffset(2025, 1, 14, 0, 0, 0, TimeSpan.Zero),
+            "2025",
+            "01",
+            true,
+            SupportPhase.Active)
+        {
+            SdkVersion = "8.0.405",
+            SdkVersions = ["8.0.405", "8.0.308", "8.0.112"],
+            Links = new Dictionary<string, HalLink>
+            {
+                [HalTerms.Self] = new("https://example.com/8.0/8.0.12/index.json")
+            }
+        };
+
+        var json = JsonSerializer.Serialize(
+            entry,
+            ReleaseVersionIndexSerializerContext.Default.PatchReleaseVersionIndexEntry);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal("8.0.405", root.GetProperty("sdk_version").GetString());
+        var sdkVersions = root.GetProperty("sdk_versions").EnumerateArray().Select(v => v.GetString()!).ToArray();
+        Assert.Equal(["8.0.405", "8.0.308", "8.0.112"], sdkVersions);
+    }
+}


### PR DESCRIPTION
## Summary

- add `sdk_versions` to patch entries in major and timeline indexes
- expose SDK version data from `PatchSummary`
- keep full globalization for the `release-notes` tool so `CompareOptions.NumericOrdering` correctly orders 10.0+ releases

Closes #52

## Validation

- `dotnet test DotnetRelease.slnx --no-restore --verbosity minimal`
- `dotnet build DotnetRelease.slnx --no-restore --verbosity minimal`
- `dotnet run --project src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj --no-restore -- generate indexes /home/rich/git/core-release-index/release-notes`