### PR TITLE
Recover PRs for squash commits without PR suffix

### DIFF
--- a/DotnetRelease.slnx
+++ b/DotnetRelease.slnx
@@ -17,5 +17,6 @@
   <Folder Name="/test/">
     <Project Path="test/Dotnet.Release.Graph.Tests/Dotnet.Release.Graph.Tests.csproj" />
     <Project Path="test/Dotnet.Release.Client.Tests/Dotnet.Release.Client.Tests.csproj" />
+    <Project Path="test/Dotnet.Release.ChangesHandler.Tests/Dotnet.Release.ChangesHandler.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
@@ -39,6 +39,14 @@ public partial class ChangeCollector(HttpClient httpClient)
                     commit.Sha
                 );
             }
+            else if (prNumber == 0)
+            {
+                var pr = await GetPullRequestForCommitAsync(org, repo, commit.Sha);
+                if (pr is not null && !prs.ContainsKey(pr.Number))
+                {
+                    prs[pr.Number] = pr;
+                }
+            }
         }
 
         return new CompareResult([.. prs.Values], orderedShas);
@@ -84,9 +92,7 @@ public partial class ChangeCollector(HttpClient httpClient)
     private async Task<List<string>> GetPrLabelsAsync(string org, string repo, int prNumber)
     {
         var url = $"{GitHubApiBase}/repos/{org}/{repo}/pulls/{prNumber}";
-        var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Add("Accept", "application/vnd.github+json");
-        request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+        var request = CreateGitHubRequest(url);
 
         var response = await httpClient.SendAsync(request);
         if (!response.IsSuccessStatusCode)
@@ -99,6 +105,44 @@ public partial class ChangeCollector(HttpClient httpClient)
         return pr?.Labels?.Select(l => l.Name).ToList() ?? [];
     }
 
+    private async Task<PullRequestInfo?> GetPullRequestForCommitAsync(string org, string repo, string sha)
+    {
+        var url = $"{GitHubApiBase}/repos/{org}/{repo}/commits/{sha}/pulls";
+        var request = CreateGitHubRequest(url);
+
+        var response = await httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            var shortSha = sha.Length > 7 ? sha[..7] : sha;
+            Console.Error.WriteLine(
+                $"Warning: GitHub commits-to-PRs API returned {response.StatusCode} for {org}/{repo}@{shortSha}: {body}");
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStreamAsync();
+        var pullRequests = await JsonSerializer.DeserializeAsync(json, GitHubSerializerContext.Default.ListGitHubPullRequest);
+        if (pullRequests is null or { Count: 0 })
+        {
+            return null;
+        }
+
+        var pullRequest = pullRequests.FirstOrDefault(
+            pr => pr.MergeCommitSha?.Equals(sha, StringComparison.OrdinalIgnoreCase) == true)
+            ?? pullRequests[0];
+
+        if (pullRequest.Number <= 0 || string.IsNullOrEmpty(pullRequest.HtmlUrl))
+        {
+            return null;
+        }
+
+        return new PullRequestInfo(
+            pullRequest.Number,
+            pullRequest.Title ?? "",
+            pullRequest.HtmlUrl,
+            sha);
+    }
+
     private async Task<List<CompareCommit>> GetCompareCommitsAsync(
         string org, string repo, string baseSha, string headSha)
     {
@@ -108,9 +152,7 @@ public partial class ChangeCollector(HttpClient httpClient)
         while (true)
         {
             var url = $"{GitHubApiBase}/repos/{org}/{repo}/compare/{baseSha}...{headSha}?per_page={MaxPerPage}&page={page}";
-            var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Add("Accept", "application/vnd.github+json");
-            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+            var request = CreateGitHubRequest(url);
 
             var response = await httpClient.SendAsync(request);
 
@@ -144,6 +186,14 @@ public partial class ChangeCollector(HttpClient httpClient)
         }
 
         return allCommits;
+    }
+
+    private static HttpRequestMessage CreateGitHubRequest(string url)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Accept", "application/vnd.github+json");
+        request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+        return request;
     }
 
     internal static int ParsePrNumber(string commitMessage)
@@ -227,12 +277,25 @@ internal record GitHubLabel(
 );
 
 internal record GitHubPullRequest(
+    [property: JsonPropertyName("number")]
+    int Number,
+
+    [property: JsonPropertyName("title")]
+    string? Title,
+
+    [property: JsonPropertyName("html_url")]
+    string? HtmlUrl,
+
+    [property: JsonPropertyName("merge_commit_sha")]
+    string? MergeCommitSha,
+
     [property: JsonPropertyName("labels")]
     IList<GitHubLabel>? Labels
 );
 
 [JsonSerializable(typeof(CompareResponse))]
 [JsonSerializable(typeof(GitHubPullRequest))]
+[JsonSerializable(typeof(List<GitHubPullRequest>))]
 internal partial class GitHubSerializerContext : JsonSerializerContext
 {
 }

--- a/test/Dotnet.Release.ChangesHandler.Tests/ChangeCollectorTests.cs
+++ b/test/Dotnet.Release.ChangesHandler.Tests/ChangeCollectorTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Dotnet.Release.ChangesHandler;
+using Xunit;
+
+namespace Dotnet.Release.ChangesHandler.Tests;
+
+public class ChangeCollectorTests
+{
+    [Fact]
+    public async Task GetMergedPullRequestsAsync_UsesCommitPullsFallbackWhenSubjectHasNoPrNumber()
+    {
+        var handler = new StubGitHubHandler
+        {
+            ["https://api.github.com/repos/dotnet/runtime/compare/base...head?per_page=100&page=1"] = """
+                {
+                  "commits": [
+                    {
+                      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "commit": {
+                        "message": "Add a fluent Validate overload (#123)"
+                      }
+                    },
+                    {
+                      "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                      "commit": {
+                        "message": "Implement X25519DiffieHellman"
+                      }
+                    }
+                  ]
+                }
+                """,
+            ["https://api.github.com/repos/dotnet/runtime/commits/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/pulls"] = """
+                [
+                  {
+                    "number": 456,
+                    "title": "Implement X25519DiffieHellman",
+                    "html_url": "https://github.com/dotnet/runtime/pull/456",
+                    "merge_commit_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  }
+                ]
+                """
+        };
+        using var httpClient = new HttpClient(handler);
+        var collector = new ChangeCollector(httpClient);
+
+        var result = await collector.GetMergedPullRequestsAsync("dotnet", "runtime", "base", "head");
+
+        Assert.Equal(["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], result.CommitShas);
+        Assert.Collection(
+            result.PullRequests,
+            pr =>
+            {
+                Assert.Equal(123, pr.Number);
+                Assert.Equal("Add a fluent Validate overload", pr.Title);
+                Assert.Equal("https://github.com/dotnet/runtime/pull/123", pr.Url);
+                Assert.Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", pr.MergeCommitSha);
+            },
+            pr =>
+            {
+                Assert.Equal(456, pr.Number);
+                Assert.Equal("Implement X25519DiffieHellman", pr.Title);
+                Assert.Equal("https://github.com/dotnet/runtime/pull/456", pr.Url);
+                Assert.Equal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", pr.MergeCommitSha);
+            });
+        Assert.DoesNotContain(
+            "https://api.github.com/repos/dotnet/runtime/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/pulls",
+            handler.RequestedUrls);
+        Assert.Contains(
+            "https://api.github.com/repos/dotnet/runtime/commits/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/pulls",
+            handler.RequestedUrls);
+    }
+
+    private sealed class StubGitHubHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _responses = new(StringComparer.Ordinal);
+
+        public List<string> RequestedUrls { get; } = [];
+
+        public string this[string url]
+        {
+            set => _responses[url] = value;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            RequestedUrls.Add(url);
+
+            if (!_responses.TryGetValue(url, out var response))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("{}")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response)
+            });
+        }
+    }
+}

--- a/test/Dotnet.Release.ChangesHandler.Tests/Dotnet.Release.ChangesHandler.Tests.csproj
+++ b/test/Dotnet.Release.ChangesHandler.Tests/Dotnet.Release.ChangesHandler.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dotnet.Release.ChangesHandler.Tests</PackageId>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dotnet.Release.ChangesHandler\Dotnet.Release.ChangesHandler.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- call GitHub commits-to-PRs for compare commits whose subject has no PR number
- keep existing subject parsing for normal merge/squash commits
- add ChangesHandler unit coverage for the fallback path

Closes #51

## Validation

- `dotnet restore DotnetRelease.slnx`
- `dotnet test DotnetRelease.slnx --no-restore --verbosity minimal`
- `dotnet build DotnetRelease.slnx --no-restore --verbosity minimal`