### PR TITLE
Add aliases[] (CVE↔GHSA correlation) to CVE disclosures

### DIFF
--- a/src/Dotnet.Release.Cve/CveRecords.cs
+++ b/src/Dotnet.Release.Cve/CveRecords.cs
@@ -86,7 +86,11 @@ public record Cve(
     string? Weakness = null,
 
     [property: Description("CVE Numbering Authority information.")]
-    Cna? Cna = null
+    Cna? Cna = null,
+
+    [property: Description("Cross-database identifiers for the same vulnerability (OSV-style aliases, e.g. a GHSA ID). Each value is self-typed by its prefix (GHSA-, CVE-, ...)."),
+        JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    IList<string>? Aliases = null
 );
 
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]

--- a/src/Dotnet.Release.Graph/CveRecordSummary.cs
+++ b/src/Dotnet.Release.Graph/CveRecordSummary.cs
@@ -46,6 +46,10 @@ public record CveRecordSummary(
     [Description("Platforms affected by the CVE"),
      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IList<string>? Platforms { get; set; }
+
+    [Description("Cross-database identifiers for the same vulnerability (OSV-style aliases, e.g. a GHSA ID). Each value is self-typed by its prefix (GHSA-, CVE-, ...)."),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IList<string>? Aliases { get; set; }
 }
 
 [Description("Collection of simplified CVE records")]


### PR DESCRIPTION
Implements scope item (1) of #56: adds an OSV-style `aliases` string array to the `Cve` disclosure record and the embedded `CveRecordSummary`.

## What

- `Cve.Aliases` (`IList<string>?`, optional, omitted when null) — serializes as `aliases` via the existing SnakeCaseLower policy.
- `CveRecordSummary.Aliases` — mirror on the embedded summary so correlation is available where CVE summaries are embedded in timeline indexes.

## Why

The release-index CVE feed keys vulnerabilities by **CVE**; nuget.org advisories key the same vulnerability by **GHSA**. With no correlation field, consumers that merge both sources (e.g. `dotnet-inspect`) must double-report or apply a fragile prefix heuristic. A self-typing `aliases[]` (OSV-aligned) makes dedup deterministic.

```json
{
  "id": "CVE-2024-38168",
  "aliases": ["GHSA-7qrv-8f9x-3h32"],
  ...
}
```

## Compatibility

Optional + `WhenWritingNull`, so existing `cve.json` output is byte-identical until the field is populated. `Cve` already uses `JsonUnmappedMemberHandling.Skip`, so round-tripping is unaffected.

## Follow-ups (not in this PR)

- Populate `aliases` in the CVE enricher from `gh api /repos/dotnet/{runtime,aspnetcore,sdk}/security-advisories`.
- Backfill existing `cve.json` files.

Full rationale / write-up: https://gist.github.com/richlander/ece91f912e90fba4471c570d5cde325c

Fixes #56