### PR TITLE
Bump library package version to 1.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
 
   <!-- NuGet package metadata -->
   <PropertyGroup>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Rich Lander</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/richlander/dotnet-release</PackageProjectUrl>


### PR DESCRIPTION
Bumps the lock-step library package version from `1.0.0` to `1.1.0` via a central `VersionPrefix` in `Directory.Build.props`.

## Why

The publish workflow (`.github/workflows/publish.yml`) pushes with `--skip-duplicate`, so packages only republish when the version changes. All library packages are currently published at `1.0.0`, so recent `src/**` changes would be skipped on the next publish.

This bump ensures new packages ship for:

- **#55** — `Dotnet.Release.ChangesHandler` (recover PRs for squash commits without PR suffix)
- **#57** — `Dotnet.Release.Cve` / `Dotnet.Release.Graph` (`aliases[]` CVE↔GHSA schema)

## Scope

- Single central `VersionPrefix` keeps the libraries lock-step (they were all `1.0.0`).
- `1.1.0` reflects the additive `aliases` schema member (new, backward-compatible API).
- Tool packages (`Dotnet.Release.Tool`, `.Tools`, `.CveEnricher`) set their own `VersionPrefix` in-project and are unaffected — verified: libraries resolve to `1.1.0`, tools stay at `3.0.0`/`1.0.1`.