### PR TITLE
Add per-major cve-index.json and generated cve.md

### DIFF
--- a/src/Dotnet.Release.CveHandler/CveTransformer.cs
+++ b/src/Dotnet.Release.CveHandler/CveTransformer.cs
@@ -48,7 +48,8 @@ public static class CveTransformer
                     : null,
                 AffectedProducts = affectedProducts?.Count > 0 ? affectedProducts : null,
                 AffectedPackages = affectedPackages?.Count > 0 ? affectedPackages : null,
-                Platforms = disclosure.Platforms
+                Platforms = disclosure.Platforms,
+                Aliases = disclosure.Aliases
             };
         }).ToList();
     }

--- a/src/Dotnet.Release.Graph/CveRecordSummary.cs
+++ b/src/Dotnet.Release.Graph/CveRecordSummary.cs
@@ -14,6 +14,9 @@ public record CveRecordSummary(
     [Description("Title describing the vulnerability")]
     string Title)
 {
+    [Description("Patch version that shipped the fix (populated in per-major cve-index.json, omitted in timeline indexes)"),
+     JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Fixed { get; set; }
     [JsonPropertyName("_links"),
      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
      Description("HAL+JSON links to related CVE resources")]

--- a/src/Dotnet.Release.Graph/LinkRelations.cs
+++ b/src/Dotnet.Release.Graph/LinkRelations.cs
@@ -19,6 +19,9 @@ public static class LinkRelations
     public const string Manifest = "manifest";
     public const string MajorManifest = "major-manifest";
     public const string CveJson = "cve-json";
+    public const string CveIndex = "cve-index";
+    public const string CveMarkdown = "cve-md";
+    public const string DisclosureMonth = "disclosure-month";
     public const string Release = "release";
     public const string ReleaseJson = "release-json";
 

--- a/src/Dotnet.Release.Graph/LinkTitles.cs
+++ b/src/Dotnet.Release.Graph/LinkTitles.cs
@@ -30,6 +30,7 @@ public static class LinkTitles
     // CVE-related
     public static readonly string CveRecordsJson = string.Intern("CVE records (JSON)");
     public static readonly string CveMarkdown = string.Intern("CVE records");
+    public static readonly string CveIndex = string.Intern("CVE index (JSON)");
 
     // Latest pointers (kind-based)
     public static readonly string LatestPatch = string.Intern("Latest patch");

--- a/src/Dotnet.Release.Graph/MajorCveIndex.cs
+++ b/src/Dotnet.Release.Graph/MajorCveIndex.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Release.Graph;
+
+/// <summary>
+/// Per-major aggregate of the CVE disclosures affecting a .NET major version.
+/// A query accelerator: one fetch answers "what affects 8.0" without crawling
+/// every timeline month. The timeline month files remain the canonical home for
+/// full disclosure detail; each embedded summary links back to its month.
+/// </summary>
+[Description("Per-major aggregate index of CVE disclosures affecting a .NET major version")]
+public record MajorCveIndex(
+    [Description("Concise title for the document")]
+    string Title,
+    [Description("Major version identifier (e.g., '8.0')")]
+    string Version)
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("Date the index was last generated (e.g., '2026-06-10')")]
+    public string? LastUpdated { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("CVE identifiers affecting this major version")]
+    public IList<string>? CveRecords { get; init; }
+
+    [JsonPropertyName("_links"),
+     Description("HAL+JSON links for hypermedia navigation")]
+    public Dictionary<string, HalLink> Links { get; init; } = [];
+
+    [JsonPropertyName("_embedded"),
+     Description("Embedded CVE disclosure summaries affecting this major version")]
+    public MajorCveIndexEmbedded? Embedded { get; set; }
+}
+
+[Description("Container for embedded major-level CVE disclosure summaries")]
+public record MajorCveIndexEmbedded
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("CVE disclosure summaries affecting this major version")]
+    public IReadOnlyList<CveRecordSummary>? Disclosures { get; set; }
+}

--- a/src/Dotnet.Release.Graph/PatchReleaseVersionIndex.cs
+++ b/src/Dotnet.Release.Graph/PatchReleaseVersionIndex.cs
@@ -118,6 +118,10 @@ public record PatchReleaseVersionIndexEntry(
      Description("All SDK versions included in this patch release")]
     public IReadOnlyList<string>? SdkVersions { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull),
+     Description("CVE identifiers fixed in this patch release")]
+    public IReadOnlyList<string>? CveRecords { get; init; }
+
     [JsonPropertyName("_links"),
      Description("HAL+JSON links for navigation")]
     public Dictionary<string, HalLink> Links { get; init; } = [];

--- a/src/Dotnet.Release.Graph/SerializerContexts.cs
+++ b/src/Dotnet.Release.Graph/SerializerContexts.cs
@@ -20,6 +20,17 @@ public partial class ReleaseVersionIndexSerializerContext : JsonSerializerContex
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     WriteIndented = true)]
+[JsonSerializable(typeof(MajorCveIndex))]
+[JsonSerializable(typeof(MajorCveIndexEmbedded))]
+[JsonSerializable(typeof(CveRecordSummary))]
+[JsonSerializable(typeof(HalLink))]
+public partial class MajorCveIndexSerializerContext : JsonSerializerContext
+{
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true)]
 [JsonSerializable(typeof(ReleaseManifest))]
 [JsonSerializable(typeof(PartialManifest))]
 public partial class ReleaseManifestSerializerContext : JsonSerializerContext

--- a/src/Dotnet.Release.IndexGenerator/CveIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/CveIndexFiles.cs
@@ -1,0 +1,241 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Dotnet.Release;
+using Dotnet.Release.Cve;
+using Dotnet.Release.CveHandler;
+using Dotnet.Release.Graph;
+
+namespace Dotnet.Release.IndexGenerator;
+
+/// <summary>
+/// Generates the per-major CVE aggregate files: <c>{major}/cve-index.json</c> (a slim,
+/// query-fast index of every CVE disclosure affecting the major version) and the
+/// human-readable <c>{major}/cve.md</c> that mirrors it.
+///
+/// The cve-index.json is intentionally slim: it inlines high-signal query fields
+/// (id, title, fixed, affected_releases, cvss, disclosure_date, aliases) and points
+/// back to the canonical timeline month for heavy detail (description, cvss vector,
+/// cna, per-package affected lists, commits).
+/// </summary>
+public static class CveIndexFiles
+{
+    public static async Task GenerateAsync(
+        string majorVersion,
+        IReadOnlyList<ReleaseVersionIndexEntry> patchEntries,
+        string inputRoot,
+        string outputMajorVersionDir)
+    {
+        // Patches are ordered newest-first. Walk them, load each month's cve.json, and
+        // collect the disclosures that affect this major version.
+        var disclosures = new List<CveRecordSummary>();
+        var cveIds = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        DateTimeOffset? lastUpdated = null;
+
+        foreach (var entry in patchEntries)
+        {
+            if (entry.CveRecords is null or { Count: 0 })
+            {
+                continue;
+            }
+
+            var gaDate = entry.Lifecycle?.GaDate;
+            if (gaDate is null)
+            {
+                continue;
+            }
+
+            var date = gaDate.Value;
+            lastUpdated ??= date;
+            var year = date.Year.ToString("D4");
+            var month = date.Month.ToString("D2");
+
+            var cveRecords = await CveLoader.LoadForReleaseDateAsync(inputRoot, date);
+            if (cveRecords?.Disclosures is null or { Count: 0 })
+            {
+                continue;
+            }
+
+            // Authoritative set of CVE IDs that affect this major in this month.
+            IEnumerable<string> idsForMajor = cveRecords.ReleaseCves?.TryGetValue(majorVersion, out var ids) == true
+                ? ids
+                : entry.CveRecords;
+
+            var idSet = idsForMajor.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var disclosure in cveRecords.Disclosures.Where(d => idSet.Contains(d.Id)))
+            {
+                if (!seen.Add(disclosure.Id))
+                {
+                    continue;
+                }
+
+                disclosures.Add(BuildSummary(disclosure, cveRecords, majorVersion, entry.Version, year, month));
+                cveIds.Add(disclosure.Id);
+            }
+        }
+
+        Directory.CreateDirectory(outputMajorVersionDir);
+
+        await WriteCveIndexJsonAsync(majorVersion, cveIds, disclosures, lastUpdated, outputMajorVersionDir);
+        await WriteCveMarkdownAsync(majorVersion, patchEntries, inputRoot, outputMajorVersionDir);
+    }
+
+    private static CveRecordSummary BuildSummary(
+        Dotnet.Release.Cve.Cve disclosure,
+        CveRecords cveRecords,
+        string majorVersion,
+        string patchVersion,
+        string year,
+        string month)
+    {
+        // `fixed` is the patch version that shipped the fix for this major. Prefer the
+        // product entry's authoritative `fixed` when present, otherwise the patch version.
+        var fixedVersion = cveRecords.Products?
+            .FirstOrDefault(p => p.CveId == disclosure.Id && p.Release == majorVersion)?.Fixed
+            ?? patchVersion;
+
+        var links = new Dictionary<string, object>();
+
+        var announcementUrl = disclosure.References?.FirstOrDefault();
+        if (announcementUrl != null)
+        {
+            links[HalTerms.Self] = new HalLink(announcementUrl);
+        }
+
+        var monthIndexPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Index}";
+        links[LinkRelations.DisclosureMonth] = new HalLink($"{Location.GitHubBaseUri}{monthIndexPath}");
+
+        var cveJsonPath = $"{FileNames.Directories.Timeline}/{year}/{month}/{FileNames.Cve}";
+        links[LinkRelations.CveJson] = new HalLink($"{Location.GitHubBaseUri}{cveJsonPath}")
+        {
+            Type = MediaType.Json
+        };
+
+        var affectedReleases = cveRecords.CveReleases?.TryGetValue(disclosure.Id, out var releases) == true
+            ? releases
+            : null;
+
+        // Slim: inline cheap high-signal fields only; leave affected_products /
+        // affected_packages / platforms to the canonical month cve.json.
+        return new CveRecordSummary(disclosure.Id, disclosure.Problem)
+        {
+            Fixed = fixedVersion,
+            Links = links,
+            CvssScore = disclosure.Cvss.Score,
+            CvssSeverity = disclosure.Cvss.Severity,
+            DisclosureDate = disclosure.Timeline.Disclosure.Date,
+            AffectedReleases = affectedReleases,
+            Aliases = disclosure.Aliases
+        };
+    }
+
+    private static async Task WriteCveIndexJsonAsync(
+        string majorVersion,
+        IReadOnlyList<string> cveIds,
+        IReadOnlyList<CveRecordSummary> disclosures,
+        DateTimeOffset? lastUpdated,
+        string outputMajorVersionDir)
+    {
+        var links = new Dictionary<string, HalLink>
+        {
+            [HalTerms.Self] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.CveIndex}")
+            {
+                Type = MediaType.Json
+            },
+            [LinkRelations.Major] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.Index}"),
+            [LinkRelations.CveMarkdown] = new HalLink($"{Location.GitHubBaseUri}{majorVersion}/{FileNames.CveMarkdown}")
+            {
+                Type = MediaType.Markdown
+            }
+        };
+
+        var index = new MajorCveIndex($".NET {majorVersion} CVE index", majorVersion)
+        {
+            LastUpdated = lastUpdated?.ToString("yyyy-MM-dd"),
+            CveRecords = cveIds.Count > 0 ? cveIds.ToList() : null,
+            Links = links,
+            Embedded = disclosures.Count > 0
+                ? new MajorCveIndexEmbedded { Disclosures = disclosures }
+                : null
+        };
+
+        var json = JsonSerializer.Serialize(index, MajorCveIndexSerializerContext.Default.MajorCveIndex);
+        var path = Path.Combine(outputMajorVersionDir, FileNames.CveIndex);
+        await File.WriteAllTextAsync(path, json + '\n');
+    }
+
+    private static async Task WriteCveMarkdownAsync(
+        string majorVersion,
+        IReadOnlyList<ReleaseVersionIndexEntry> patchEntries,
+        string inputRoot,
+        string outputMajorVersionDir)
+    {
+        var majorNumber = majorVersion.Split('.')[0];
+        var labelSlug = $".NET {majorVersion}".Replace(" ", "%20");
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"# .NET {majorNumber} CVEs");
+        sb.AppendLine();
+        sb.AppendLine($"The .NET Team releases [monthly updates for .NET {majorNumber}](https://github.com/dotnet/announcements/labels/{labelSlug}) on [Patch Tuesday](https://en.wikipedia.org/wiki/Patch_Tuesday). These updates often include security fixes. If you are on an older version, your app may be vulnerable.");
+        sb.AppendLine();
+        sb.AppendLine($"Your app needs to be on the latest .NET {majorNumber} patch version to be secure. The longer you wait to upgrade, the greater the exposure to CVEs.");
+        sb.AppendLine();
+        sb.AppendLine("## Which CVEs apply to my app?");
+        sb.AppendLine();
+        sb.AppendLine("Your app may be vulnerable to the following published security [CVEs](https://www.cve.org/) if you are using an older version.");
+        sb.AppendLine();
+
+        var anyRows = false;
+        foreach (var entry in patchEntries)
+        {
+            var gaDate = entry.Lifecycle?.GaDate;
+            if (gaDate is null)
+            {
+                continue;
+            }
+
+            anyRows = true;
+            var monthYear = gaDate.Value.ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+            sb.AppendLine($"- {entry.Version} ({monthYear})");
+
+            if (entry.CveRecords is null or { Count: 0 })
+            {
+                sb.AppendLine("  - No new CVEs.");
+                continue;
+            }
+
+            var date = gaDate.Value;
+            var cveRecords = await CveLoader.LoadForReleaseDateAsync(inputRoot, date);
+            IEnumerable<string> monthIds = cveRecords?.ReleaseCves?.TryGetValue(majorVersion, out var ids) == true
+                ? ids
+                : entry.CveRecords;
+            var idSet = monthIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var matched = cveRecords?.Disclosures?.Where(d => idSet.Contains(d.Id)).ToList();
+            if (matched is null or { Count: 0 })
+            {
+                sb.AppendLine("  - No new CVEs.");
+                continue;
+            }
+
+            foreach (var disclosure in matched)
+            {
+                var url = disclosure.References?.FirstOrDefault();
+                var link = url != null
+                    ? $"[{disclosure.Id} | {disclosure.Problem}]({url})"
+                    : $"{disclosure.Id} | {disclosure.Problem}";
+                sb.AppendLine($"  - {link}");
+            }
+        }
+
+        if (!anyRows)
+        {
+            sb.AppendLine($"No CVEs have been published for .NET {majorNumber} yet. This page will be updated when .NET {majorNumber} reaches GA.");
+        }
+
+        var path = Path.Combine(outputMajorVersionDir, FileNames.CveMarkdown);
+        await File.WriteAllTextAsync(path, sb.ToString());
+    }
+}

--- a/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
@@ -336,8 +336,9 @@ public class ReleaseIndexFiles
                             links[LinkRelations.SecurityDisclosures] = new HalLink($"{Location.GitHubBaseUri}{monthIndexPath}");
                         }
 
-                        // Note: CVE IDs (cve_records) are intentionally omitted from patch entries.
-                        // CVEs are a timeline concept - use month or cve-json link.
+                        // Surface the CVE identifiers fixed in this patch so the parent index
+                        // mirrors the child patch index.json root (symmetry with sdk_versions).
+                        // Full disclosure detail stays in the timeline month / cve-json.
                         return new PatchReleaseVersionIndexEntry(
                             e.Version,
                             gaDate,
@@ -348,6 +349,7 @@ public class ReleaseIndexFiles
                         {
                             SdkVersion = e.SdkVersions?.FirstOrDefault(),
                             SdkVersions = e.SdkVersions,
+                            CveRecords = e.CveRecords?.Count > 0 ? e.CveRecords : null,
                             Links = HalHelpers.OrderLinks(links)
                         };
                     }).ToList())
@@ -369,6 +371,9 @@ public class ReleaseIndexFiles
             var patchIndexPath = Path.Combine(outputMajorVersionDir, FileNames.Index);
             var finalPatchIndexJson = (updatedPatchIndexJson ?? patchIndexJson) + '\n';
             await File.WriteAllTextAsync(patchIndexPath, finalPatchIndexJson);
+
+            // Generate the per-major CVE aggregate (cve-index.json) and human-readable cve.md.
+            await CveIndexFiles.GenerateAsync(majorVersionDirName, patchEntries, inputDir, outputMajorVersionDir);
 
             // Same links as the major version index, but with a different base directory (to force different pathing)
             // NOTE: Do NOT add latest-patch or latest-month links here - those change monthly

--- a/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
@@ -366,11 +366,6 @@ public class ReleaseIndexFiles
                         };
                     }).ToList())
                 {
-                    CveRecords = patchEntries
-                        .Where(e => e.CveRecords?.Count > 0)
-                        .SelectMany(e => e.CveRecords!)
-                        .Distinct()
-                        .ToList() is { Count: > 0 } aggregateCves ? aggregateCves : null,
                     SdkFeatureBands = sdkFeatureBandEntries
                 } : null
             };

--- a/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
+++ b/src/Dotnet.Release.IndexGenerator/ReleaseIndexFiles.cs
@@ -166,6 +166,18 @@ public class ReleaseIndexFiles
                 Title = LinkTitles.DotNetReleaseIndex,
             };
 
+            // 2c. Add links to the per-major CVE aggregate (always generated for the major)
+            orderedMajorVersionLinks[LinkRelations.CveIndex] = new HalLink($"{Location.GitHubBaseUri}{majorVersionDirName}/{FileNames.CveIndex}")
+            {
+                Title = $"{LinkTitles.CveIndex} - .NET {majorVersionDirName}",
+                Type = MediaType.Json
+            };
+            orderedMajorVersionLinks[LinkRelations.CveMarkdown] = new HalLink($"{Location.GitHubBaseUri}{majorVersionDirName}/{FileNames.CveMarkdown}")
+            {
+                Title = $"{LinkTitles.CveMarkdown} - .NET {majorVersionDirName}",
+                Type = MediaType.Markdown
+            };
+
             // 3. Add latest and latest-security HAL+JSON links
             if (latestPatch != null)
             {
@@ -354,6 +366,11 @@ public class ReleaseIndexFiles
                         };
                     }).ToList())
                 {
+                    CveRecords = patchEntries
+                        .Where(e => e.CveRecords?.Count > 0)
+                        .SelectMany(e => e.CveRecords!)
+                        .Distinct()
+                        .ToList() is { Count: > 0 } aggregateCves ? aggregateCves : null,
                     SdkFeatureBands = sdkFeatureBandEntries
                 } : null
             };

--- a/src/Dotnet.Release/FileNames.cs
+++ b/src/Dotnet.Release/FileNames.cs
@@ -9,6 +9,8 @@ public static class FileNames
     public const string Releases = "releases.json";
     public const string Release = "release.json";
     public const string Cve = "cve.json";
+    public const string CveIndex = "cve-index.json";
+    public const string CveMarkdown = "cve.md";
     public const string Changes = "changes.json";
     public const string SupportedOs = "supported-os.json";
     public const string OsPackages = "os-packages.json";


### PR DESCRIPTION
## Summary

Adds a per-major CVE aggregate to the release-index schema and generates the human-readable `cve.md` from it.

For each major (e.g. `release-notes/8.0/`):

- **`cve-index.json`** — a slim, query-fast `MajorCveIndex` (mirrors the `HistoryMonthIndex` shape). One fetch answers "what CVEs affect 8.0" without crawling every timeline month. Root carries a flat `cve_records` id list; `_embedded.disclosures[]` holds slim `CveRecordSummary` entries.
- **`cve.md`** — projected from the index: patches newest-first with dates, CVE bullets or "No new CVEs.", and a per-major templated intro. Previously hand-maintained; now generated.

## Design

**Slim, not a slice.** Each embedded disclosure inlines only high-signal query fields (`id`, `title`, `fixed`, `affected_releases`, `cvss_score`/`cvss_severity`, `disclosure_date`, `aliases`) and points back to the **canonical timeline month** for heavy detail (description, cvss vector, cna, per-package affected lists, commits) via per-entry `_links`:

- `self` -> the announcement (`references[0]`)
- `disclosure-month` -> `timeline/{y}/{m}/index.json`
- `cve-json` -> `timeline/{y}/{m}/cve.json`

**Symmetry.** Embedded patch entries in `{major}/index.json` now carry `cve_records`, matching the patch child `index.json` root and `sdk_versions` (reverses the prior "intentionally omitted" decision).

**`fixed`.** New optional field on `CveRecordSummary` = the patch version that shipped the fix (from `products[].fixed` where `release == major`). Populated in `cve-index.json`, omitted in timeline indexes (ambiguous there). Reuses existing `products[].fixed` vocabulary.

**Aliases.** `CveTransformer.ToSummaries` now also emits `aliases` (GHSA<->CVE correlation from #57), so they surface in timeline summaries too.

## Changes

- New `MajorCveIndex` / `MajorCveIndexEmbedded` graph types + `MajorCveIndexSerializerContext`.
- New `CveIndexFiles` generator, wired into `ReleaseIndexFiles.GenerateAsync`.
- `FileNames`: `cve-index.json`, `cve.md`. `LinkRelations`: `cve-index`, `cve-md`, `disclosure-month`. `LinkTitles`: CVE index.
- `CveRecordSummary.Fixed`; `PatchReleaseVersionIndexEntry.CveRecords`.

## Verification

Built clean (`TreatWarningsAsErrors`); Graph + Client tests pass. Ran `generate version-index` against a copy of the live release-index: `8.0/cve-index.json` (31 disclosures, `fixed`/`aliases`/`affected_releases` populated, slim), `8.0/cve.md`, and `cve_records` symmetry on `8.0/index.json` patches all verified.

Relates to #56.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
