### PR TITLE
Fix squash PR-number resolution (link PR, not closed issue)

### DIFF
--- a/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
+++ b/src/Dotnet.Release.ChangesHandler/ChangeCollector.cs
@@ -205,11 +205,17 @@ public partial class ChangeCollector(HttpClient httpClient)
             return int.Parse(mergeMatch.Groups[1].Value);
         }
 
-        // Match "(#123)" in squash merge titles
-        var squashMatch = SquashPrRegex().Match(commitMessage);
-        if (squashMatch.Success)
+        // Match "(#123)" in squash merge titles. GitHub appends the PR number as the
+        // *last* "(#N)" on the subject (first) line, e.g.
+        //   "Add FULL OUTER JOIN support (#37633) (#38340)"
+        // where #37633 is an inline issue reference and #38340 is the actual PR.
+        // Only consider the subject line and take the last match so inline issue/PR
+        // references earlier in the title are never mistaken for the merged PR.
+        var subject = commitMessage.Split('\n', 2)[0];
+        var squashMatches = SquashPrRegex().Matches(subject);
+        if (squashMatches.Count > 0)
         {
-            return int.Parse(squashMatch.Groups[1].Value);
+            return int.Parse(squashMatches[^1].Groups[1].Value);
         }
 
         return 0;
@@ -226,9 +232,10 @@ public partial class ChangeCollector(HttpClient httpClient)
             return lines.Length > 1 ? lines[1].Trim() : "";
         }
 
-        // For squash merges: "Fix something (#123)"
+        // For squash merges: "Fix something (#123)". Strip only the trailing PR
+        // number that GitHub appends, leaving any inline issue references intact.
         var title = commitMessage.Split('\n')[0].Trim();
-        title = SquashPrRegex().Replace(title, "").Trim();
+        title = TrailingSquashPrRegex().Replace(title, "").Trim();
         return title;
     }
 
@@ -237,6 +244,9 @@ public partial class ChangeCollector(HttpClient httpClient)
 
     [GeneratedRegex(@"\(#(\d+)\)")]
     private static partial Regex SquashPrRegex();
+
+    [GeneratedRegex(@"\s*\(#\d+\)\s*$")]
+    private static partial Regex TrailingSquashPrRegex();
 }
 
 /// <summary>

--- a/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
+++ b/src/Dotnet.Release.Tools/Dotnet.Release.Tools.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>release-notes</ToolCommandName>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <PackageId>release-notes</PackageId>
     <Description>Maintainer CLI for generating and verifying .NET release notes data</Description>
     <!-- Size optimizations for Native AOT -->

--- a/test/Dotnet.Release.ChangesHandler.Tests/ChangeCollectorTests.cs
+++ b/test/Dotnet.Release.ChangesHandler.Tests/ChangeCollectorTests.cs
@@ -70,6 +70,48 @@ public class ChangeCollectorTests
             handler.RequestedUrls);
     }
 
+    [Fact]
+    public async Task GetMergedPullRequestsAsync_UsesTrailingPrNumberWhenSubjectHasMultiple()
+    {
+        // GitHub squash subjects can carry an inline issue reference plus the trailing
+        // PR number, e.g. "Add FULL OUTER JOIN support (#37633) (#38340)" where #37633 is
+        // the closed issue and #38340 is the actual PR. The trailing (#N) must win, and
+        // the cleaned title must keep the inline reference.
+        var handler = new StubGitHubHandler
+        {
+            ["https://api.github.com/repos/dotnet/efcore/compare/base...head?per_page=100&page=1"] = """
+                {
+                  "commits": [
+                    {
+                      "sha": "cccccccccccccccccccccccccccccccccccccccc",
+                      "commit": {
+                        "message": "Add FULL OUTER JOIN support (#37633) (#38340)\n\nCloses #37633"
+                      }
+                    }
+                  ]
+                }
+                """
+        };
+        using var httpClient = new HttpClient(handler);
+        var collector = new ChangeCollector(httpClient);
+
+        var result = await collector.GetMergedPullRequestsAsync("dotnet", "efcore", "base", "head");
+
+        Assert.Collection(
+            result.PullRequests,
+            pr =>
+            {
+                Assert.Equal(38340, pr.Number);
+                Assert.Equal("Add FULL OUTER JOIN support (#37633)", pr.Title);
+                Assert.Equal("https://github.com/dotnet/efcore/pull/38340", pr.Url);
+                Assert.Equal("cccccccccccccccccccccccccccccccccccccccc", pr.MergeCommitSha);
+            });
+        // The subject already yields a PR number, so no commits-to-PRs fallback call is made.
+        Assert.DoesNotContain(
+            "https://api.github.com/repos/dotnet/efcore/commits/cccccccccccccccccccccccccccccccccccccccc/pulls",
+            handler.RequestedUrls);
+    }
+
     private sealed class StubGitHubHandler : HttpMessageHandler
     {
         private readonly Dictionary<string, string> _responses = new(StringComparer.Ordinal);


### PR DESCRIPTION
## Summary

Fixes change-record URLs that linked to a **closed issue** instead of the **PR that introduced the commit**.

`ChangeCollector.ParsePrNumber` matched the **first** `(#N)` token in a squash-merge subject. GitHub appends the real PR number as the **last** `(#N)` on the subject line, so:

```
Add FULL OUTER JOIN support (#37633) (#38340)
```

(verified on efcore commit `7ca70b9`) resolved to issue **#37633** instead of PR **#38340**, mislinking the change `url`.

## Changes

- **`ParsePrNumber`** — parse only the subject (first) line and take the **last** `(#N)`, so inline issue/PR references earlier in the title can't be mistaken for the merged PR.
- **`CleanTitle`** — strip only the trailing PR number, preserving faithful inline issue references (e.g. title stays `Add FULL OUTER JOIN support (#37633)`).
- **Regression test** in `ChangeCollectorTests` for the multi-`(#N)` subject.
- Bump `release-notes` tool to **1.0.2** so consumers (the release-notes workflow) pick up the fix.

## Validation

- `dotnet test test/Dotnet.Release.ChangesHandler.Tests -c Release` → **2 passed, 0 failed** (existing fallback test + new regression test).

Supersedes #60 (which was based on a stale branch).
